### PR TITLE
Fix non ORI constants

### DIFF
--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from . import common
 from . import elf32

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -691,9 +691,14 @@ class SymbolFunction(SymbolText):
                 symbol = self.context.getConstant(constant)
                 if symbol is not None:
                     return self.generateHiLoStr(instr, symbol.name)
+
                 if instr.uniqueId == instructions.InstructionId.LUI:
-                    return f"(0x{constant:X} >> 16)"
-                return f"(0x{constant:X} & 0xFFFF)"
+                    loInstr = self.instructions[self.hiToLowDict[instructionOffset] // 4]
+                    if loInstr.uniqueId == instructions.InstructionId.ORI:
+                        return f"(0x{constant:X} >> 16)"
+                elif instr.uniqueId == instructions.InstructionId.ORI:
+                    return f"(0x{constant:X} & 0xFFFF)"
+                return self.generateHiLoStr(instr, f"0x{constant:X}")
 
             elif instr.uniqueId == instructions.InstructionId.LUI:
                 return f"(0x{instr.immediate<<16:X} >> 16)"


### PR DESCRIPTION
If a LUI instruction isn't paired with an ORI for loading a constant, then the `>> 16` / `& 0xFFFF` syntax produces a non matching disassembly.

non matching example:
```mips
/* 05CAEC 8005BEEC 3C0D031A */  lui        $t5, (0x319D560 >> 16)
/* 05CAF0 8005BEF0 25ADD560 */  addiu      $t5, $t5, (0x319D560 & 0xFFFF)
```

fixed version:
```mips
/* 05CAEC 8005BEEC 3C0D031A */  lui        $t5, %hi(0x319D560)
/* 05CAF0 8005BEF0 25ADD560 */  addiu      $t5, $t5, %lo(0x319D560)
```