### PR TITLE
1.0.2

### DIFF
--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/Context.py
+++ b/spimdisasm/common/Context.py
@@ -176,7 +176,7 @@ class ContextSymbolBase:
     def getSymbolLabel(self) -> str:
         label = ""
         if self.isStatic():
-            label += "/* static variable */\n"
+            label += "/* static variable */" + GlobalConfig.LINE_ENDS
         if self.sectionType == FileSectionType.Text:
             label += GlobalConfig.ASM_TEXT_LABEL
         else:

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -76,7 +76,7 @@ class ElementBase:
             if GlobalConfig.GLABEL_ASM_COUNT:
                 if self.index is not None:
                     label += f" # {self.index}"
-            label += "\n"
+            label +=  GlobalConfig.LINE_ENDS
             return label
         return ""
 

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -70,6 +70,8 @@ class GlobalConfig:
     USE_DOT_SHORT: bool = True
     """Disassemble symbols marked as shorts with .short instead of .word"""
 
+    LINE_ENDS: str = "\n"
+
 
     QUIET: bool = False
     VERBOSE: bool = False

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -123,27 +123,26 @@ def writeSplittedFunctionToFile(f: TextIO, func: symbols.SymbolFunction, rodataF
 
     if len(rdataList) > 0:
         # Write the rdata
-        f.write(".rdata\n")
+        f.write(".rdata" + common.GlobalConfig.LINE_ENDS)
         for sym in rdataList:
             f.write(sym.disassemble())
-            f.write("\n")
+            f.write(common.GlobalConfig.LINE_ENDS)
 
     if len(lateRodataList) > 0:
         # Write the late_rodata
-        f.write(".late_rodata\n")
+        f.write(".late_rodata" + common.GlobalConfig.LINE_ENDS)
         if lateRodataSize / len(func.instructions) > 1/3:
             align = 4
             firstLateRodataVram = lateRodataList[0].vram
             if firstLateRodataVram is not None and firstLateRodataVram % 8 == 0:
                 align = 8
-            f.write(f".late_rodata_alignment {align}\n")
+            f.write(f".late_rodata_alignment {align}" + common.GlobalConfig.LINE_ENDS)
         for sym in lateRodataList:
             f.write(sym.disassemble())
-            f.write("\n")
+            f.write(common.GlobalConfig.LINE_ENDS)
 
     if len(rdataList) > 0 or len(lateRodataList) > 0:
-        f.write("\n")
-        f.write(".text\n")
+        f.write(common.GlobalConfig.LINE_ENDS + ".text" + common.GlobalConfig.LINE_ENDS)
 
     # Write the function
     f.write(func.disassemble())
@@ -165,5 +164,5 @@ def writeOtherRodata(path: str, rodataFileList: list[sections.SectionRodata]):
 
             rodataSymbolPath = os.path.join(rodataPath, rodataSym.name) + ".s"
             with open(rodataSymbolPath, "w") as f:
-                f.write(".rdata\n")
+                f.write(".rdata" + common.GlobalConfig.LINE_ENDS)
                 f.write(rodataSym.disassemble())

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -39,16 +39,16 @@ class FileBase(common.ElementBase):
     def getAsmPrelude(self) -> str:
         output = ""
 
-        output += ".include \"macro.inc\"\n"
-        output += "\n"
-        output += "# assembler directives\n"
-        output += ".set noat      # allow manual use of $at\n"
-        output += ".set noreorder # don't insert nops after branches\n"
-        output += ".set gp=64     # allow use of 64-bit general purpose registers\n"
-        output += "\n"
-        output += f".section {self.sectionType.toSectionName()}\n"
-        output += "\n"
-        output += ".balign 16\n"
+        output += ".include \"macro.inc\"" + common.GlobalConfig.LINE_ENDS
+        output += common.GlobalConfig.LINE_ENDS
+        output += "# assembler directives" + common.GlobalConfig.LINE_ENDS
+        output += ".set noat      # allow manual use of $at" + common.GlobalConfig.LINE_ENDS
+        output += ".set noreorder # don't insert nops after branches" + common.GlobalConfig.LINE_ENDS
+        output += ".set gp=64     # allow use of 64-bit general purpose registers" + common.GlobalConfig.LINE_ENDS
+        output += common.GlobalConfig.LINE_ENDS
+        output += f".section {self.sectionType.toSectionName()}" + common.GlobalConfig.LINE_ENDS
+        output += common.GlobalConfig.LINE_ENDS
+        output += ".balign 16" + common.GlobalConfig.LINE_ENDS
 
         return output
 
@@ -126,12 +126,12 @@ class FileBase(common.ElementBase):
         for i, sym in enumerate(self.symbolList):
             output += sym.disassemble()
             if i + 1 < len(self.symbolList):
-                output += "\n"
+                output += common.GlobalConfig.LINE_ENDS
         return output
 
     def disassembleToFile(self, f: TextIO):
         f.write(self.getAsmPrelude())
-        f.write("\n")
+        f.write(common.GlobalConfig.LINE_ENDS)
         f.write(self.disassemble())
 
 

--- a/spimdisasm/mips/instructions/MipsInstructionBase.py
+++ b/spimdisasm/mips/instructions/MipsInstructionBase.py
@@ -544,7 +544,7 @@ class InstructionBase:
 
     def getFloatRegisterName(self, register: int) -> str:
         if not InstructionConfig.NAMED_REGISTERS:
-            return f"${register}"
+            return f"$f{register}"
         if InstructionConfig.FPR_ABI_NAMES == AbiNames.numeric:
             if register == 31 and not InstructionConfig.USE_FPCCSR:
                 return "$31"

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -141,7 +141,7 @@ class SymbolBase(common.ElementBase):
                 contextSym = self.getSymbolAtVramOrOffset(localOffset+j)
                 if contextSym is not None:
                     # Possible symbols in the middle
-                    label = "\n" + contextSym.getSymbolLabel() + "\n"
+                    label = common.GlobalConfig.LINE_ENDS + contextSym.getSymbolLabel()  + common.GlobalConfig.LINE_ENDS
 
             if isByte:
                 shiftValue = 24 - (j * 8)
@@ -173,7 +173,7 @@ class SymbolBase(common.ElementBase):
             output += f"{label}{comment} {dotType} {value}"
             if j == 0 and i < len(self.endOfLineComment):
                 output += self.endOfLineComment[i]
-            output += "\n"
+            output += common.GlobalConfig.LINE_ENDS
 
         return output, 0
 

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -20,7 +20,7 @@ class SymbolBss(SymbolBase):
     def disassembleAsBss(self) -> str:
         output = self.getLabel()
         output += self.generateAsmLineComment(0)
-        output += f" .space 0x{self.spaceSize:02X}\n"
+        output += f" .space 0x{self.spaceSize:02X}" + common.GlobalConfig.LINE_ENDS
         return output
 
     def disassemble(self) -> str:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -730,11 +730,11 @@ class SymbolFunction(SymbolText):
                 labelSym.isDefined = True
                 labelSym.sectionType = self.sectionType
                 if labelSym.type == common.SymbolSpecialType.function or labelSym.type == common.SymbolSpecialType.jumptablelabel:
-                    return labelSym.getSymbolLabel() + "\n"
-                return labelSym.name + ":\n"
+                    return labelSym.getSymbolLabel() + common.GlobalConfig.LINE_ENDS
+                return labelSym.getName() + ":" + common.GlobalConfig.LINE_ENDS
 
             if instructionOffset in self.localLabels:
-                return self.localLabels[instructionOffset] + ":\n"
+                return self.localLabels[instructionOffset] + ":" + common.GlobalConfig.LINE_ENDS
         return ""
 
 
@@ -746,7 +746,7 @@ class SymbolFunction(SymbolText):
                 return self.disassembleAsData()
 
         if self.isLikelyHandwritten:
-            output += "/* Handwritten function */\n"
+            output += "/* Handwritten function */" + common.GlobalConfig.LINE_ENDS
 
         output += self.getLabel()
 
@@ -766,13 +766,13 @@ class SymbolFunction(SymbolText):
                 instr.extraLjustWidthOpcode += 1
 
             label = self.getLabelForOffset(instructionOffset)
-            output += f"{label}{comment}  {line}\n"
+            output += f"{label}{comment}  {line}" + common.GlobalConfig.LINE_ENDS
 
             wasLastInstABranch = instr.isBranch() or instr.isJump()
             instructionOffset += 4
 
         if common.GlobalConfig.ASM_TEXT_END_LABEL:
-            output += f"{common.GlobalConfig.ASM_TEXT_END_LABEL} {self.name}\n"
+            output += f"{common.GlobalConfig.ASM_TEXT_END_LABEL} {self.name}" + common.GlobalConfig.LINE_ENDS
 
         return output
 

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -110,7 +110,7 @@ class SymbolRodata(SymbolBase):
         # try to get the symbol name from the offset of the file (possibly from a .o elf file)
         possibleSymbolName = self.context.getOffsetGenericSymbol(self.inFileOffset + localOffset, self.sectionType)
         if possibleSymbolName is not None:
-            label = possibleSymbolName.getSymbolLabel() + "\n"
+            label = possibleSymbolName.getSymbolLabel() + common.GlobalConfig.LINE_ENDS
 
         if len(self.context.relocSymbols[self.sectionType]) > 0:
             possibleReference = self.context.getRelocSymbol(self.inFileOffset + localOffset, self.sectionType)
@@ -144,7 +144,7 @@ class SymbolRodata(SymbolBase):
                     decodedValue, rawStringSize = common.Utils.decodeString(buffer, 4*i)
                     dotType = ".asciz"
                     value = f'"{decodedValue}"'
-                    value += "\n" + (22 * " ") + ".balign 4"
+                    value += common.GlobalConfig.LINE_ENDS + (22 * " ") + ".balign 4"
                     rodataWord = None
                     skip = rawStringSize // 4
                 except (UnicodeDecodeError, RuntimeError):
@@ -152,4 +152,4 @@ class SymbolRodata(SymbolBase):
                     pass
 
         comment = self.generateAsmLineComment(localOffset, rodataWord)
-        return f"{label}{comment} {dotType} {value}\n", skip
+        return f"{label}{comment} {dotType} {value}" + common.GlobalConfig.LINE_ENDS, skip


### PR DESCRIPTION
- Fix missing `f` on float registers when `GlobalConfig.NAMED_REGISTERS` was set to `False`
- Allow changing the line ends to anything via `GlobalConfig.LINE_ENDS`