### PR TITLE
1.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,28 +11,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build wheel
-        run: pip wheel .
+      - name: Install build module
+        run: pip install build
+
+      - name: Build wheel and source
+        run: python -m build --sdist --wheel --outdir dist/ .
 
       - uses: actions/upload-artifact@v2
         with:
-          path: ./*.whl
-
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build sdist
-        run: pipx run build --sdist
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: dist/*.tar.gz
+          path: dist/*
 
   upload_pypi:
-    needs: [build_wheel, build_sdist]
+    needs: [build_wheel]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="spimdisasm",
-    version="1.0.4",
+    version="1.0.5",
     author="Decompollaborate",
     license="MIT",
     description="N64 MIPS disassembler",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    modules="spimdisasm",
 )

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -60,7 +60,9 @@ class GlobalConfig:
 
     ASM_TEXT_LABEL: str = "glabel"
     ASM_DATA_LABEL: str = "glabel"
+    ASM_TEXT_ENT_LABEL: str = ""
     ASM_TEXT_END_LABEL: str = ""
+    ASM_TEXT_FUNC_AS_LABEL: bool = False
 
     PRINT_NEW_FILE_BOUNDARIES: bool = False
     """Print to stdout every file boundary found in .text and .rodata"""
@@ -120,7 +122,9 @@ class GlobalConfig:
 
         miscConfig.add_argument("--asm-text-label", help=f"Changes the label used to declare functions. Defaults to {GlobalConfig.ASM_TEXT_LABEL}")
         miscConfig.add_argument("--asm-data-label", help=f"Changes the label used to declare data symbols. Defaults to {GlobalConfig.ASM_DATA_LABEL}")
+        miscConfig.add_argument("--asm-ent-label", help=f"Tells the disassembler to start using an ent label for functions")
         miscConfig.add_argument("--asm-end-label", help=f"Tells the disassembler to start using an end label for functions")
+        miscConfig.add_argument("--asm-func-as-label", help=f"Toggle adding the function name as an additional label. Defaults to {GlobalConfig.ASM_TEXT_FUNC_AS_LABEL}", action=argparse.BooleanOptionalAction)
 
         miscConfig.add_argument("--print-new-file-boundaries", help=f"Print to stdout any new file boundary found. Defaults to {GlobalConfig.PRINT_NEW_FILE_BOUNDARIES}", action=argparse.BooleanOptionalAction)
 
@@ -184,8 +188,12 @@ class GlobalConfig:
             GlobalConfig.ASM_TEXT_LABEL = args.asm_text_label
         if args.asm_data_label:
             GlobalConfig.ASM_DATA_LABEL = args.asm_data_label
+        if args.asm_ent_label:
+            GlobalConfig.ASM_TEXT_ENT_LABEL = args.asm_ent_label
         if args.asm_end_label:
             GlobalConfig.ASM_TEXT_END_LABEL = args.asm_end_label
+        if args.asm_func_as_label is not None:
+            GlobalConfig.ASM_TEXT_FUNC_AS_LABEL = args.asm_func_as_label
 
         if args.print_new_file_boundaries is not None:
             GlobalConfig.PRINT_NEW_FILE_BOUNDARIES = args.print_new_file_boundaries

--- a/spimdisasm/mips/instructions/MipsConstants.py
+++ b/spimdisasm/mips/instructions/MipsConstants.py
@@ -50,6 +50,9 @@ class InstructionId(enum.Enum):
     DDIV      = enum.auto() # Doubleword DIVide
     DDIVU     = enum.auto() # Doubleword DIVide Unsigned
 
+    SN64_DIV  = enum.auto() # DIVide word
+    SN64_DIVU = enum.auto() # DIVide Unsigned word
+
     ADD       = enum.auto() # ADD word
     ADDU      = enum.auto() # ADD Unsigned word
     SUB       = enum.auto() # Subtract word
@@ -437,8 +440,8 @@ instructionDescriptorDict: dict[InstructionId|InstructionVectorId, InstrDescript
     InstructionId.MOVN      : InstrDescriptor(["rd", "rs", "rt"], InstrType.typeR, modifiesRd=True),
     InstructionId.DIV       : InstrDescriptor(["rd", "rs", "rt"], InstrType.typeR),
     InstructionId.DIVU      : InstrDescriptor(["rd", "rs", "rt"], InstrType.typeR),
-    # InstructionId.DIV       : InstrDescriptor(["rs", "rt"], InstrType.typeR),
-    # InstructionId.DIVU      : InstrDescriptor(["rs", "rt"], InstrType.typeR),
+    InstructionId.SN64_DIV  : InstrDescriptor(["rs", "rt"], InstrType.typeR),
+    InstructionId.SN64_DIVU : InstrDescriptor(["rs", "rt"], InstrType.typeR),
     InstructionId.DDIV      : InstrDescriptor(["rd", "rs", "rt"], InstrType.typeR),
     InstructionId.DDIVU     : InstrDescriptor(["rd", "rs", "rt"], InstrType.typeR),
     # InstructionId.DDIV      : InstrDescriptor(["rs", "rt"], InstrType.typeR),

--- a/spimdisasm/mips/instructions/MipsInstructionBase.py
+++ b/spimdisasm/mips/instructions/MipsInstructionBase.py
@@ -544,6 +544,8 @@ class InstructionBase:
 
     def getFloatRegisterName(self, register: int) -> str:
         if not InstructionConfig.NAMED_REGISTERS:
+            if register == 31:
+                return f"${register}"
             return f"$f{register}"
         if InstructionConfig.FPR_ABI_NAMES == AbiNames.numeric:
             if register == 31 and not InstructionConfig.USE_FPCCSR:

--- a/spimdisasm/mips/instructions/MipsInstructionBase.py
+++ b/spimdisasm/mips/instructions/MipsInstructionBase.py
@@ -381,6 +381,7 @@ class InstructionBase:
 
         self.vram: int|None = None
         self._handwrittenCategory: bool = False
+        self.inHandwrittenFunction: bool = False
 
     @property
     def instr(self) -> int:

--- a/spimdisasm/mips/instructions/MipsInstructionConfig.py
+++ b/spimdisasm/mips/instructions/MipsInstructionConfig.py
@@ -52,7 +52,7 @@ class InstructionConfig:
     """Enables a few fixes for SN64's assembler related to div/divu instructions
 
     - SN64's assembler doesn't like assembling `div $0, a, b` with .set noat active.
-    Removing the $0 fixes this issue.
+    Removing the $0 fixes this issue (but not for handwritten asm)
 
     - SN64's assembler expands div to have break if dividing by zero
     However, the break it generates is different than the one it generates with `break N`

--- a/spimdisasm/mips/instructions/MipsInstructionConfig.py
+++ b/spimdisasm/mips/instructions/MipsInstructionConfig.py
@@ -48,6 +48,14 @@ class InstructionConfig:
     PSEUDO_INSTRUCTIONS: bool = True
     """Produce pseudo instructions (like `move`, `nop` or `b`) whenever those should match the desired original instruction"""
 
+    PSEUDO_BEQZ: bool = True
+    PSEUDO_BNEZ: bool = True
+    PSEUDO_B: bool = True
+    PSEUDO_MOVE: bool = True
+    PSEUDO_NOT: bool = True
+    PSEUDO_NEGU: bool = True
+
+
     SN64_DIV_FIX: bool = False
     """Enables a few fixes for SN64's assembler related to div/divu instructions
 

--- a/spimdisasm/mips/instructions/MipsInstructionNormal.py
+++ b/spimdisasm/mips/instructions/MipsInstructionNormal.py
@@ -99,10 +99,13 @@ class InstructionNormal(InstructionBase):
             if self.rt == 0:
                 if self.uniqueId == InstructionId.BEQ:
                     if self.rs == 0:
-                        self.uniqueId = InstructionId.B
+                        if InstructionConfig.PSEUDO_B:
+                            self.uniqueId = InstructionId.B
                     else:
-                        self.uniqueId = InstructionId.BEQZ
+                        if InstructionConfig.PSEUDO_BEQZ:
+                            self.uniqueId = InstructionId.BEQZ
                 elif self.uniqueId == InstructionId.BNE:
-                    self.uniqueId = InstructionId.BNEZ
+                    if InstructionConfig.PSEUDO_BNEZ:
+                        self.uniqueId = InstructionId.BNEZ
 
         self.descriptor = instructionDescriptorDict[self.uniqueId]

--- a/spimdisasm/mips/instructions/MipsInstructionSpecial.py
+++ b/spimdisasm/mips/instructions/MipsInstructionSpecial.py
@@ -114,10 +114,6 @@ class InstructionSpecial(InstructionBase):
             if self.rd != 31:
                 self.descriptor = instructionDescriptorDict[InstructionId.JALR_RD]
 
-        if InstructionConfig.SN64_DIV_FIX:
-            if self.uniqueId in (InstructionId.DIV, InstructionId.DIVU):
-                self.descriptor.operands = ["rs", "rt"]
-
 
     def blankOut(self):
         self.rs = 0
@@ -129,6 +125,16 @@ class InstructionSpecial(InstructionBase):
     def disassembleInstruction(self, immOverride: str|None=None) -> str:
         patch = False
 
+        if InstructionConfig.SN64_DIV_FIX:
+            if self.uniqueId == InstructionId.BREAK:
+                patch = True
+            elif self.uniqueId == InstructionId.DIV:
+                if not self.inHandwrittenFunction:
+                    self.descriptor = instructionDescriptorDict[InstructionId.SN64_DIV]
+            elif self.uniqueId == InstructionId.DIVU:
+                if not self.inHandwrittenFunction:
+                    self.descriptor = instructionDescriptorDict[InstructionId.SN64_DIVU]
+
         if self.descriptor.instrType == InstrType.typeR and "code" not in self.descriptor.operands:
             if "rs" not in self.descriptor.operands and self.rs != 0:
                 patch = True
@@ -137,10 +143,6 @@ class InstructionSpecial(InstructionBase):
             if "rd" not in self.descriptor.operands and self.rd != 0 and self.uniqueId != InstructionId.JALR:
                 patch = True
             if "sa" not in self.descriptor.operands and self.sa != 0:
-                patch = True
-
-        if InstructionConfig.SN64_DIV_FIX:
-            if self.uniqueId == InstructionId.BREAK:
                 patch = True
 
         if patch:

--- a/spimdisasm/mips/instructions/MipsInstructionSpecial.py
+++ b/spimdisasm/mips/instructions/MipsInstructionSpecial.py
@@ -94,18 +94,21 @@ class InstructionSpecial(InstructionBase):
     def processUniqueId(self):
         self.uniqueId = self.SpecialOpcodes.get(self.function, InstructionId.INVALID)
 
-        if InstructionConfig.PSEUDO_INSTRUCTIONS:
-            if self.instr == 0:
-                self.uniqueId = InstructionId.NOP
-            elif self.rt == 0:
+        if self.instr == 0:
+            # NOP is special enough
+            self.uniqueId = InstructionId.NOP
+        elif InstructionConfig.PSEUDO_INSTRUCTIONS:
+            if self.rt == 0:
                 if self.uniqueId == InstructionId.OR:
-                    if self.rs != 0:
+                    if InstructionConfig.PSEUDO_MOVE:
                         self.uniqueId = InstructionId.MOVE
                 elif self.uniqueId == InstructionId.NOR:
-                    self.uniqueId = InstructionId.NOT
+                    if InstructionConfig.PSEUDO_NOT:
+                        self.uniqueId = InstructionId.NOT
             elif self.uniqueId == InstructionId.SUBU:
                 if self.rs == 0:
-                    self.uniqueId = InstructionId.NEGU
+                    if InstructionConfig.PSEUDO_NEGU:
+                        self.uniqueId = InstructionId.NEGU
 
         self.descriptor = instructionDescriptorDict[self.uniqueId]
 

--- a/spimdisasm/mips/instructions/MipsInstructionSpecial.py
+++ b/spimdisasm/mips/instructions/MipsInstructionSpecial.py
@@ -99,7 +99,8 @@ class InstructionSpecial(InstructionBase):
                 self.uniqueId = InstructionId.NOP
             elif self.rt == 0:
                 if self.uniqueId == InstructionId.OR:
-                    self.uniqueId = InstructionId.MOVE
+                    if self.rs != 0:
+                        self.uniqueId = InstructionId.MOVE
                 elif self.uniqueId == InstructionId.NOR:
                     self.uniqueId = InstructionId.NOT
             elif self.uniqueId == InstructionId.SUBU:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -549,6 +549,9 @@ class SymbolFunction(SymbolText):
 
         self._processElfRelocSymbols()
 
+        for instr in self.instructions:
+            instr.inHandwrittenFunction = self.isLikelyHandwritten
+
 
     def countDiffOpcodes(self, other: SymbolFunction) -> int:
         result = 0

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -750,6 +750,12 @@ class SymbolFunction(SymbolText):
 
         output += self.getLabel()
 
+        if common.GlobalConfig.ASM_TEXT_ENT_LABEL:
+            output += f"{common.GlobalConfig.ASM_TEXT_ENT_LABEL} {self.name}" + common.GlobalConfig.LINE_ENDS
+
+        if common.GlobalConfig.ASM_TEXT_FUNC_AS_LABEL:
+            output += f"{self.name}:" + common.GlobalConfig.LINE_ENDS
+
         wasLastInstABranch = False
         instructionOffset = 0
         for instr in self.instructions:


### PR DESCRIPTION
- Allow setting a .ent and the function name as a label
- Float register `$31` fix for `NAMED_REGISTERS=False`
- Fix CI builds (2)
- Only apply the SN64 DIV fix for non handwritten functions
- Finer control over pseudo instructions