### PR TITLE
1.1.1: Symbol finding fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # spimdisasm
 
------
-
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/spimdisasm)](https://pypi.org/project/spimdisasm/)
 ![GitHub](https://img.shields.io/github/license/Decompollaborate/spimdisasm)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/Decompollaborate/spimdisasm)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # spimdisasm
 
+-----
+
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/spimdisasm)](https://pypi.org/project/spimdisasm/)
+![GitHub](https://img.shields.io/github/license/Decompollaborate/spimdisasm)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/Decompollaborate/spimdisasm)
+![PyPI](https://img.shields.io/pypi/v/spimdisasm)
+![GitHub contributors](https://img.shields.io/github/contributors/Decompollaborate/spimdisasm?logo=purple)
+
 A matching MIPS disassembler API and front-ends with built-in instruction analysis.
 
 Currently supports all the CPU instructions for MIPS I, II, III and IV.

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="spimdisasm",
-    version="1.1.0",
+    version="1.1.1",
     author="Decompollaborate",
     license="MIT",
+    url="https://github.com/Decompollaborate/spimdisasm",
     description="N64 MIPS disassembler",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 1, 0)
+__version_info__ = (1, 1, 1)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/mips/instructions/MipsConstants.py
+++ b/spimdisasm/mips/instructions/MipsConstants.py
@@ -587,10 +587,10 @@ instructionDescriptorDict: dict[InstructionId|InstructionVectorId, InstrDescript
     InstructionId.ERET      : InstrDescriptor([], InstrType.typeUnknown),
 
     # OP IMM
-    InstructionId.BC0T      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isFloat=True),
-    InstructionId.BC0F      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isFloat=True),
-    InstructionId.BC0TL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True, isFloat=True),
-    InstructionId.BC0FL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True, isFloat=True),
+    InstructionId.BC0T      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True),
+    InstructionId.BC0F      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True),
+    InstructionId.BC0TL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True),
+    InstructionId.BC0FL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True),
 
     # OP rt, fs
     InstructionId.MFC1      : InstrDescriptor(["rt", "fs"], InstrType.typeUnknown, isFloat=True, modifiesRt=True),
@@ -601,10 +601,10 @@ instructionDescriptorDict: dict[InstructionId|InstructionVectorId, InstrDescript
     InstructionId.CTC1      : InstrDescriptor(["rt", "fs"], InstrType.typeUnknown, isFloat=True),
 
     # OP IMM
-    InstructionId.BC1F      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isFloat=True),
-    InstructionId.BC1T      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isFloat=True),
-    InstructionId.BC1FL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True, isFloat=True),
-    InstructionId.BC1TL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True, isFloat=True),
+    InstructionId.BC1F      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True),
+    InstructionId.BC1T      : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True),
+    InstructionId.BC1FL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True),
+    InstructionId.BC1TL     : InstrDescriptor(["IMM"], InstrType.typeUnknown, isBranch=True, isBranchLikely=True),
 
     # OP fd, fs, ft
     InstructionId.ADD_S     : InstrDescriptor(["fd", "fs", "ft"], InstrType.typeUnknown, isFloat=True),

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -155,6 +155,14 @@ class SymbolFunction(SymbolText):
         # lui being None means this symbol is a $gp access
         assert (luiInstr is None and luiOffset is None) or (luiInstr is not None and luiOffset is not None)
 
+        if lowerOffset in self.pointersPerInstruction:
+            # This %lo has been processed already
+            if luiOffset is None:
+                return None
+            if luiOffset + 4 != lowerOffset:
+                # Make an exception if the lower instruction is just after the LUI
+                return None
+
         if luiInstr is None and common.GlobalConfig.GP_VALUE is None:
             return None
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -321,9 +321,9 @@ class SymbolFunction(SymbolText):
         if contextSym is not None:
             contextSym.setTypeIfUnset(instrType)
 
-    def _symbolFinder(self, instr: instructions.InstructionBase, prevInstr: instructions.InstructionBase, instructionOffset: int, trackedRegisters: dict[int, int], trackedRegistersAll: dict[int, int], registersValues: dict[int, tuple[int, int]]):
+    def _symbolFinder(self, instr: instructions.InstructionBase, prevInstr: instructions.InstructionBase|None, instructionOffset: int, trackedRegisters: dict[int, int], trackedRegistersAll: dict[int, int], registersValues: dict[int, tuple[int, int]]):
         if instr.uniqueId == instructions.InstructionId.LUI:
-            if not prevInstr.isBranchLikely():
+            if prevInstr is None or not prevInstr.isBranchLikely():
                 # If the previous instructions is a branch likely, then nulify
                 # the effects of this instruction for future analysis
                 trackedRegisters[instr.rt] = instructionOffset//4
@@ -379,7 +379,8 @@ class SymbolFunction(SymbolText):
         if branchOffset <= 0 or branch//4 >= len(self.instructions):
             return
 
-        self._removeRegisterFromTrackers(instr, None, None, trackedRegisters, trackedRegistersAll, registersValues, False)
+        if lastInstr.isBranchLikely():
+            self._symbolFinder(instr, None, instructionOffset, trackedRegisters, trackedRegistersAll, registersValues)
 
         pairedLoFound = False
         i = 0

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -160,7 +160,7 @@ class SymbolFunction(SymbolText):
             if luiOffset is None:
                 return None
             luiInstrPrev = self.instructions[(luiOffset-4)//4]
-            if luiInstrPrev.isBranchLikely():
+            if luiInstrPrev.isBranchLikely() or luiInstrPrev.isUnconditionalBranch():
                 # This lui will be nullified afterwards, so it is likely for it to be a symbol
                 pass
             elif luiOffset + 4 != lowerOffset:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -368,8 +368,13 @@ class SymbolFunction(SymbolText):
         if not lastInstr.isBranch() and not lastInstr.isUnconditionalBranch():
             return
 
-        branchOffset = lastInstr.getBranchOffset() - 4
+        if lastInstr.uniqueId == instructions.InstructionId.J:
+            targetBranchVram = lastInstr.getInstrIndexAsVram()
+            branchOffset = targetBranchVram - self.getVramOffset(instructionOffset)
+        else:
+            branchOffset = lastInstr.getBranchOffset() - 4
         branch = instructionOffset + branchOffset
+
         # don't check negative branches (loops) or branches outside this function
         if branchOffset <= 0 or branch//4 >= len(self.instructions):
             return

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -469,10 +469,6 @@ class SymbolFunction(SymbolText):
             branchOffset = lastInstr.getBranchOffset() - 4
         branch = instructionOffset + branchOffset
 
-        # don't check negative branches (loops) or branches outside this function
-        if branchOffset <= 0 or branch//4 >= len(self.instructions):
-            return
-
         if instr.uniqueId == instructions.InstructionId.LUI:
             self._symbolFinder(instr, None, instructionOffset, trackedRegisters, trackedRegistersAll, registersValues, registersDereferencedValues)
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -159,7 +159,11 @@ class SymbolFunction(SymbolText):
             # This %lo has been processed already
             if luiOffset is None:
                 return None
-            if luiOffset + 4 != lowerOffset:
+            luiInstrPrev = self.instructions[(luiOffset-4)//4]
+            if luiInstrPrev.isBranchLikely():
+                # This lui will be nullified afterwards, so it is likely for it to be a symbol
+                pass
+            elif luiOffset + 4 != lowerOffset:
                 # Make an exception if the lower instruction is just after the LUI
                 return None
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -153,11 +153,7 @@ class SymbolFunction(SymbolText):
 
     def _processSymbol(self, luiInstr: instructions.InstructionBase|None, luiOffset: int|None, lowerInstr: instructions.InstructionBase, lowerOffset: int) -> int|None:
         # lui being None means this symbol is a $gp access
-        assert ((luiInstr is None and luiOffset is None) or (luiInstr is not None and luiOffset is not None))
-
-        if lowerOffset in self.pointersPerInstruction:
-            # This %lo has been processed already
-            return self.pointersPerInstruction[lowerOffset]
+        assert (luiInstr is None and luiOffset is None) or (luiInstr is not None and luiOffset is not None)
 
         if luiInstr is None and common.GlobalConfig.GP_VALUE is None:
             return None


### PR DESCRIPTION
Various fixes:
- Multiples workarounds for pairing multiples %hi to the same %lo
- Fix `J` target calculation for the look ahead symbol finder
- Special cases for `LUI`s on delay slots
- Track moving registers by using `MOVE`, `OR` and `ADDU`
- Invalidate some registers after function calls
- Check negative branches
- Fix jump table detector for SN64