### PR TITLE
1.2.2: %hi/%lo symbol filtering fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.2.1
+version = 1.2.2
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 2, 1)
+__version_info__ = (1, 2, 2)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -191,7 +191,7 @@ class InstrAnalyzer:
         # filter out stuff that may not be a real symbol
         filterOut = common.GlobalConfig.SYMBOL_FINDER_FILTER_LOW_ADDRESSES and address < 0x80000000
         filterOut |= common.GlobalConfig.SYMBOL_FINDER_FILTER_HIGH_ADDRESSES and address >= 0xC0000000
-        if filterOut:
+        if filterOut and lowerInstr.uniqueId != rabbitizer.InstrId.cpu_addiu:
             if common.GlobalConfig.SYMBOL_FINDER_FILTERED_ADDRESSES_AS_CONSTANTS:
                 # Let's pretend this value is a constant
                 constant = address


### PR DESCRIPTION
Prevents filtering out LUI/ADDIU combos from being real symbols