### PR TITLE
Misc changes in preparation for better RSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Mainly focused on supporting Nintendo 64 binaries, but it should work with other
 - Some workarounds for some specific compilers/assemblers:
   - `SN64`:
     - `div`/`divu` fix: tweaks a bit the produced `div`, `divu` and `break` instructions.
-- (Experimental) N64 RSP disassembly support.
-  - NOTE: This mode has not been tested to even be assemblable.
+- N64 RSP instruction disassembly support.
+  - RSP decoding has been tested to build back to matching assemblies with [armips](https://github.com/Kingcom/armips/).
 - (Experimental) Same VRAM overlay support.
   - Overlays which are able to reference symbols from other overlays in other categories/types is supported too.
   - NOTE: This feature lacks lots of testing and probably has many bugs.
@@ -59,6 +59,8 @@ Every front-end script has its own `--help` screen.
 - `disasmdis.py`: Disassembles raw hex passed to the CLI as a MIPS instruction.
 
 - `elfObjDisasm.py`: \[EXPERIMENTAL\] Allows to disassemble `.o` elf files. Generated assembly files are not guaranteed to match or be assemblable.
+
+- `rspDisasm.py`: Disassemblies RSP binaries.
 
 ### Back-end
 

--- a/disasmdis.py
+++ b/disasmdis.py
@@ -18,9 +18,8 @@ def disasmdisMain():
 
     parser.add_argument("input", help="Hex words to be disassembled. Leading '0x' must be omitted")
 
-    parser.add_argument("--raw-instr", help="Print raw instructions without performing analyzis on them", action=spimdisasm.common.Utils.BooleanOptionalAction)
-
     parser.add_argument("--endian", help="Set the endianness of input files. Defaults to 'big'", choices=["big", "little", "middle"])
+    parser.add_argument("--category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp"])
 
     args = parser.parse_args()
 
@@ -49,15 +48,14 @@ def disasmdisMain():
             array_of_bytes[j] = int(wordStr[j*2:(j+1)*2], 16)
 
         word = spimdisasm.common.Utils.bytesToBEWords(array_of_bytes)[0]
-        instructionList.append(rabbitizer.Instruction(word))
 
-    if args.raw_instr:
-        for instr in instructionList:
-            print(instr.disassemble())
-    else:
-        func = spimdisasm.mips.symbols.SymbolFunction(context, 0, 0, 0, 0, instructionList, 0, None)
-        func.analyze()
-        print(func.disassemble(), end="")
+        category = rabbitizer.InstrCategory.CPU
+        if args.category == "rsp":
+            category = rabbitizer.InstrCategory.RSP
+        instructionList.append(rabbitizer.Instruction(word, category=category))
+
+    for instr in instructionList:
+        print(instr.disassemble())
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.0.0,<2.0.0
+rabbitizer>=1.1.0,<2.0.0

--- a/rspDisasm.py
+++ b/rspDisasm.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import spimdisasm
+import rabbitizer
+
+
+def rspDisasmMain():
+    description = "RSP N64 disassembler"
+    parser = argparse.ArgumentParser(description=description)
+
+
+    parser.add_argument("binary", help="Path to input binary")
+    parser.add_argument("output", help="Path to output. Use '-' to print to stdout instead")
+
+    parser.add_argument("--start", help="Raw offset of the input binary file to start disassembling. Expects an hex value", default="0")
+    parser.add_argument("--end", help="Offset end of the input binary file to start disassembling. Expects an hex value",  default="0xFFFFFF")
+    parser.add_argument("--vram", help="Set the VRAM address. Expects an hex value", default="0x0")
+
+
+    spimdisasm.common.GlobalConfig.GLABEL_ASM_COUNT = False
+    spimdisasm.common.GlobalConfig.ASM_TEXT_FUNC_AS_LABEL = True
+    spimdisasm.common.GlobalConfig.ASM_USE_PRELUDE = False
+    spimdisasm.common.GlobalConfig.ASM_USE_SYMBOL_LABEL = False
+    rabbitizer.config.misc_unknownInstrComment = False
+
+
+    spimdisasm.common.Context.addParametersToArgParse(parser)
+
+    spimdisasm.common.GlobalConfig.addParametersToArgParse(parser)
+
+    spimdisasm.mips.InstructionConfig.addParametersToArgParse(parser)
+
+    args = parser.parse_args()
+
+    spimdisasm.mips.InstructionConfig.parseArgs(args)
+
+    spimdisasm.common.GlobalConfig.parseArgs(args)
+
+
+    context = spimdisasm.common.Context()
+    context.parseArgs(args)
+
+    array_of_bytes = spimdisasm.common.Utils.readFileAsBytearray(args.binary)
+    input_name = os.path.splitext(os.path.split(args.binary)[1])[0]
+
+
+    start = int(args.start, 16)
+    end = int(args.end, 16)
+    fileVram = int(args.vram, 16)
+
+    f = spimdisasm.mips.sections.SectionText(context, start, end, fileVram, input_name, array_of_bytes, 0, None)
+    f.isRsp = True
+
+    highestVromEnd = len(array_of_bytes)
+    lowestVramStart = 0x00000000
+    highestVramEnd = lowestVramStart + highestVromEnd
+    fileVram = int(args.vram, 16)
+    if fileVram != 0:
+        lowestVramStart = fileVram
+        highestVramEnd = fileVram + highestVromEnd
+
+    context.globalSegment.changeRanges(0, highestVromEnd, lowestVramStart, highestVramEnd)
+
+    f.analyze()
+    f.printAnalyzisResults()
+
+
+    spimdisasm.mips.FilesHandlers.writeSection(args.output, f)
+
+
+    if args.save_context is not None:
+        contextPath = Path(args.save_context)
+        contextPath.parent.mkdir(parents=True, exist_ok=True)
+        context.saveContextToFile(contextPath)
+
+
+if __name__ == "__main__":
+    rspDisasmMain()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.3.1
+version = 1.3.2
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler
@@ -17,4 +17,4 @@ long_description_content_type = text/markdown
 [options]
 packages = find:
 install_requires =
-    rabbitizer>=1.0.0,<2.0.0
+    rabbitizer>=1.1.0,<2.0.0

--- a/singleFileDisasm.py
+++ b/singleFileDisasm.py
@@ -113,9 +113,11 @@ def disassemblerMain():
         dataOutput = textOutput
 
     highestVromEnd = len(array_of_bytes)
-    highestVramEnd = 0x80000000 + highestVromEnd
+    lowestVramStart = 0x80000000
+    highestVramEnd = lowestVramStart + highestVromEnd
     fileVram = int(args.vram, 16)
     if fileVram != 0:
+        lowestVramStart = fileVram
         highestVramEnd = (fileVram & 0xF0000000) + highestVromEnd
 
     for row in splits:
@@ -151,7 +153,7 @@ def disassemblerMain():
         processedFiles[row.section].append(f)
         processedFilesOutputPaths[row.section].append(outputFilePath)
 
-    context.globalSegment.changeRanges(0, highestVromEnd, 0x80000000, highestVramEnd)
+    context.globalSegment.changeRanges(0, highestVromEnd, lowestVramStart, highestVramEnd)
 
     i = 0
     for section, filesInSection in processedFiles.items():

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 3, 1)
+__version_info__ = (1, 3, 2)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -246,6 +246,8 @@ class ContextSymbol:
         return f"{self.getName()} + 0x{address - self.address:X}"
 
     def getSymbolLabel(self) -> str:
+        if not GlobalConfig.ASM_USE_SYMBOL_LABEL:
+            return ""
         label = ""
         if self.isStatic():
             label += "# static variable" + GlobalConfig.LINE_ENDS

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -84,6 +84,8 @@ class ElementBase:
         "Generates a glabel for the passed symbol, including an optional index value if it was set and it is enabled in the GlobalConfig"
         if sym is not None:
             label = sym.getSymbolLabel()
+            if not label:
+                return ""
             if GlobalConfig.GLABEL_ASM_COUNT:
                 if self.index is not None:
                     label += f" # {self.index}"

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -84,6 +84,7 @@ class GlobalConfig:
     ASM_TEXT_ENT_LABEL: str = ""
     ASM_TEXT_END_LABEL: str = ""
     ASM_TEXT_FUNC_AS_LABEL: bool = False
+    ASM_USE_PRELUDE: bool = True
 
     PRINT_NEW_FILE_BOUNDARIES: bool = False
     """Print to stdout every file boundary found in .text and .rodata"""
@@ -148,6 +149,7 @@ class GlobalConfig:
         miscConfig.add_argument("--asm-ent-label", help=f"Tells the disassembler to start using an ent label for functions")
         miscConfig.add_argument("--asm-end-label", help=f"Tells the disassembler to start using an end label for functions")
         miscConfig.add_argument("--asm-func-as-label", help=f"Toggle adding the function name as an additional label. Defaults to {GlobalConfig.ASM_TEXT_FUNC_AS_LABEL}", action=Utils.BooleanOptionalAction)
+        miscConfig.add_argument("--asm-use-prelude", help=f"Toggle use of the default prelude for asm files. Defaults to {GlobalConfig.ASM_USE_PRELUDE}", action=Utils.BooleanOptionalAction)
 
         miscConfig.add_argument("--print-new-file-boundaries", help=f"Print to stdout any new file boundary found. Defaults to {GlobalConfig.PRINT_NEW_FILE_BOUNDARIES}", action=Utils.BooleanOptionalAction)
 
@@ -221,6 +223,8 @@ class GlobalConfig:
             GlobalConfig.ASM_TEXT_END_LABEL = args.asm_end_label
         if args.asm_func_as_label is not None:
             GlobalConfig.ASM_TEXT_FUNC_AS_LABEL = args.asm_func_as_label
+        if args.asm_use_prelude is not None:
+            GlobalConfig.ASM_USE_PRELUDE = args.asm_use_prelude
 
         if args.print_new_file_boundaries is not None:
             GlobalConfig.PRINT_NEW_FILE_BOUNDARIES = args.print_new_file_boundaries

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -81,6 +81,7 @@ class GlobalConfig:
 
     ASM_TEXT_LABEL: str = "glabel"
     ASM_DATA_LABEL: str = "glabel"
+    ASM_USE_SYMBOL_LABEL: bool = True
     ASM_TEXT_ENT_LABEL: str = ""
     ASM_TEXT_END_LABEL: str = ""
     ASM_TEXT_FUNC_AS_LABEL: bool = False
@@ -146,6 +147,7 @@ class GlobalConfig:
 
         miscConfig.add_argument("--asm-text-label", help=f"Changes the label used to declare functions. Defaults to {GlobalConfig.ASM_TEXT_LABEL}")
         miscConfig.add_argument("--asm-data-label", help=f"Changes the label used to declare data symbols. Defaults to {GlobalConfig.ASM_DATA_LABEL}")
+        miscConfig.add_argument("--asm-use-symbol-label", help=f"Toggles the use of labels for symbols. Defaults to {GlobalConfig.ASM_USE_SYMBOL_LABEL}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--asm-ent-label", help=f"Tells the disassembler to start using an ent label for functions")
         miscConfig.add_argument("--asm-end-label", help=f"Tells the disassembler to start using an end label for functions")
         miscConfig.add_argument("--asm-func-as-label", help=f"Toggle adding the function name as an additional label. Defaults to {GlobalConfig.ASM_TEXT_FUNC_AS_LABEL}", action=Utils.BooleanOptionalAction)
@@ -217,6 +219,8 @@ class GlobalConfig:
             GlobalConfig.ASM_TEXT_LABEL = args.asm_text_label
         if args.asm_data_label:
             GlobalConfig.ASM_DATA_LABEL = args.asm_data_label
+        if args.asm_use_symbol_label is not None:
+            GlobalConfig.ASM_USE_SYMBOL_LABEL = args.asm_use_symbol_label
         if args.asm_ent_label:
             GlobalConfig.ASM_TEXT_ENT_LABEL = args.asm_ent_label
         if args.asm_end_label:

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -161,8 +161,9 @@ class FileBase(common.ElementBase):
         return output
 
     def disassembleToFile(self, f: TextIO):
-        f.write(self.getAsmPrelude())
-        f.write(common.GlobalConfig.LINE_ENDS)
+        if common.GlobalConfig.ASM_USE_PRELUDE:
+            f.write(self.getAsmPrelude())
+            f.write(common.GlobalConfig.LINE_ENDS)
         f.write(self.disassemble())
 
 

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -127,7 +127,10 @@ class SymbolBase(common.ElementBase):
                 contextSym = self.getSymbolAtVramOrOffset(localOffset+j)
                 if contextSym is not None:
                     # Possible symbols in the middle
-                    label = common.GlobalConfig.LINE_ENDS + contextSym.getSymbolLabel()  + common.GlobalConfig.LINE_ENDS
+                    label = common.GlobalConfig.LINE_ENDS
+                    symLabel = contextSym.getSymbolLabel()
+                    if symLabel:
+                        label += symLabel + common.GlobalConfig.LINE_ENDS
 
             if isByte:
                 shiftValue = 24 - (j * 8)

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -404,7 +404,9 @@ class SymbolFunction(SymbolText):
         labelSym.isDefined = True
         labelSym.sectionType = self.sectionType
         if labelSym.type == common.SymbolSpecialType.function or labelSym.type == common.SymbolSpecialType.jumptablelabel:
-            label = labelSym.getSymbolLabel() + common.GlobalConfig.LINE_ENDS
+            label = labelSym.getSymbolLabel()
+            if label:
+                label += common.GlobalConfig.LINE_ENDS
             if common.GlobalConfig.ASM_TEXT_FUNC_AS_LABEL:
                 label += f"{labelSym.getName()}:{common.GlobalConfig.LINE_ENDS}"
             return label

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -419,7 +419,9 @@ class SymbolFunction(SymbolText):
                 return self.disassembleAsData()
 
         if self.isLikelyHandwritten:
-            output += "# Handwritten function" + common.GlobalConfig.LINE_ENDS
+            if not self.isRsp:
+                # RSP functions are always handwritten, so this is redundant
+                output += "# Handwritten function" + common.GlobalConfig.LINE_ENDS
 
         output += self.getLabel()
 

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -125,7 +125,9 @@ class SymbolRodata(SymbolBase):
         # try to get the symbol name from the offset of the file (possibly from a .o elf file)
         possibleSymbolName = self.context.getOffsetGenericSymbol(self.inFileOffset + localOffset, self.sectionType)
         if possibleSymbolName is not None:
-            label = possibleSymbolName.getSymbolLabel() + common.GlobalConfig.LINE_ENDS
+            label = possibleSymbolName.getSymbolLabel()
+            if label:
+                label += common.GlobalConfig.LINE_ENDS
 
         if len(self.context.relocSymbols[self.sectionType]) > 0:
             possibleReference = self.context.getRelocSymbol(self.inFileOffset + localOffset, self.sectionType)


### PR DESCRIPTION
- Fixes `singleFileDisasm.py` to allow VRAMs lower than 0x80000000
- Flag to disable using the default asm prelude (`--no-asm-use-prelude`).
- Stop outputting the "Handwritten function" on RSP functions.
- Flag to disable symbol labels like `glabel func_yadayada` (`--no-asm-use-symbol-label`).
- Add RSP support to `disasmdis.py`
- `rspDisasm.py` script focused on disassembling RSP binaries