### PR TITLE
1.5.3: More default banned symbols

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.5.2
+version = 1.5.3
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 5, 2)
+__version_info__ = (1, 5, 3)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/common/Context.py
+++ b/spimdisasm/common/Context.py
@@ -19,6 +19,7 @@ class Context:
     N64DefaultBanned = {
         0x7FFFFFE0, # osInvalICache
         0x7FFFFFF0, # osInvalDCache, osWritebackDCache, osWritebackDCacheAll
+        0x7FFFFFFF,
         0x80000010,
         0x80000020,
     }

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -149,7 +149,9 @@ class ContextSymbol:
     def isStatic(self) -> bool:
         if self.type == SymbolSpecialType.jumptablelabel:
             return False
-        return self.getName().startswith(".")
+        if self.name is None:
+            return False
+        return self.name.startswith(".")
 
     def isLateRodata(self) -> bool:
         # if self.referenceCounter > 1: return False # ?

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -311,8 +311,7 @@ class ContextRelocSymbol(ContextSymbol):
     relocType: int = -1 # Same number as the .elf specification
 
     def __init__(self, offset: int, name: str|None, relocSection: FileSectionType, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.address = offset
+        super().__init__(offset, *args, **kwargs)
         self.name = name
         self.relocSection = relocSection
 


### PR DESCRIPTION
- Add `0x7FFFFFFF` to the list of default banned symbols