### PR TITLE
1.5.6: More SN64 tweaks and data/rodata endianess

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.5.5
+version = 1.5.6
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 5, 5)
+__version_info__ = (1, 5, 6)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/common/Context.py
+++ b/spimdisasm/common/Context.py
@@ -59,10 +59,12 @@ class Context:
         self.got: GlobalOffsetTable = GlobalOffsetTable()
 
 
-    def addOverlaySegment(self, overlayCategory: str, segmentVromStart: int, segmentVromEnd: int, segmentVramStart: int, segmentVramEnd: int) -> None:
+    def addOverlaySegment(self, overlayCategory: str, segmentVromStart: int, segmentVromEnd: int, segmentVramStart: int, segmentVramEnd: int) -> SymbolsSegment:
         if overlayCategory not in self.overlaySegments:
             self.overlaySegments[overlayCategory] = dict()
-        self.overlaySegments[overlayCategory][segmentVromStart] = SymbolsSegment(segmentVromStart, segmentVromEnd, segmentVramStart, segmentVramEnd, overlayCategory=overlayCategory)
+        segment = SymbolsSegment(segmentVromStart, segmentVromEnd, segmentVramStart, segmentVramEnd, overlayCategory=overlayCategory)
+        self.overlaySegments[overlayCategory][segmentVromStart] = segment
+        return segment
 
 
     def getOffsetSymbol(self, offset: int, sectionType: FileSectionType) -> ContextOffsetSymbol|None:

--- a/spimdisasm/common/FileSectionType.py
+++ b/spimdisasm/common/FileSectionType.py
@@ -41,6 +41,8 @@ class FileSectionType(enum.Enum):
             return FileSectionType.Data
         if x == ".rodata":
             return FileSectionType.Rodata
+        if x == ".rdata":
+            return FileSectionType.Rodata
         if x == ".bss":
             return FileSectionType.Bss
         if x == ".reloc":

--- a/spimdisasm/common/FileSplitFormat.py
+++ b/spimdisasm/common/FileSplitFormat.py
@@ -54,6 +54,9 @@ class FileSplitFormat:
             elif fileName == ".rodata":
                 section = FileSectionType.Rodata
                 continue
+            elif fileName == ".rdata":
+                section = FileSectionType.Rodata
+                continue
             elif fileName == ".bss":
                 section = FileSectionType.Bss
                 continue

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -67,6 +67,10 @@ class GlobalConfig:
 
     ENDIAN: InputEndian = InputEndian.BIG
     """Endian for input binary files"""
+    ENDIAN_DATA: InputEndian|None = None
+    """If not None then specifies the endian for the .data section"""
+    ENDIAN_RODATA: InputEndian|None = None
+    """If not None then specifies the endian for the .rodata section"""
 
     GP_VALUE: int|None = None
     """Value used for $gp relocation loads and stores"""

--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -186,7 +186,7 @@ bannedEscapeCharacters = {
 
 escapeCharactersSpecialCases = {0x1B, 0x8C, 0x8D}
 
-def decodeString(buf: bytearray, offset: int) -> tuple[list[str], int]:
+def decodeString(buf: bytearray, offset: int, stringEncoding: str) -> tuple[list[str], int]:
     result = []
 
     dst = bytearray()
@@ -197,7 +197,7 @@ def decodeString(buf: bytearray, offset: int) -> tuple[list[str], int]:
             raise RuntimeError()
         elif char in escapeCharactersSpecialCases:
             if dst:
-                decoded = rabbitizer.Utils.escapeString(dst.decode("EUC-JP"))
+                decoded = rabbitizer.Utils.escapeString(dst.decode(stringEncoding))
                 result.append(decoded)
                 dst.clear()
             result.append(f"\\x{char:02X}")
@@ -209,7 +209,7 @@ def decodeString(buf: bytearray, offset: int) -> tuple[list[str], int]:
         raise RuntimeError("Reached the end of the buffer without finding an 0")
 
     if dst:
-        decoded = rabbitizer.Utils.escapeString(dst.decode("EUC-JP"))
+        decoded = rabbitizer.Utils.escapeString(dst.decode(stringEncoding))
         result.append(decoded)
     return result, i
 

--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -67,7 +67,7 @@ def readJson(filepath):
 def removeExtraWhitespace(line: str) -> str:
     return " ".join(line.split())
 
-def bytesToWords(array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=None) -> list[int]:
+def endianessBytesToWords(endian: InputEndian, array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=None) -> list[int]:
     totalBytesCount = len(array_of_bytes)
     if totalBytesCount == 0:
         return list()
@@ -77,7 +77,7 @@ def bytesToWords(array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=N
         bytesCount = offsetEnd
     bytesCount -= offset
 
-    if GlobalConfig.ENDIAN == InputEndian.MIDDLE:
+    if endian == InputEndian.MIDDLE:
         # Convert middle endian to big endian
         halfwords = bytesCount//2
         little_byte_format = f"<{halfwords}H"
@@ -87,23 +87,29 @@ def bytesToWords(array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=N
 
     words = bytesCount//4
     endian_format = f">{words}I"
-    if GlobalConfig.ENDIAN == InputEndian.LITTLE:
+    if endian == InputEndian.LITTLE:
         endian_format = f"<{words}I"
     return list(struct.unpack_from(endian_format, array_of_bytes, offset))
+
+def bytesToWords(array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=None) -> list[int]:
+    return endianessBytesToWords(GlobalConfig.ENDIAN, array_of_bytes, offset, offsetEnd)
 
 #! deprecated
 bytesToBEWords = bytesToWords
 
-def wordsToBytes(words_list: list[int], buffer: bytearray) -> bytearray:
-    if GlobalConfig.ENDIAN == InputEndian.MIDDLE:
-        raise BufferError("TODO: wordsToBytes: GlobalConfig.ENDIAN == InputEndian.MIDDLE")
+def endianessWordsToBytes(endian: InputEndian, words_list: list[int], buffer: bytearray) -> bytearray:
+    if endian == InputEndian.MIDDLE:
+        raise BufferError("TODO: wordsToBytesEndianess: GlobalConfig.ENDIAN == InputEndian.MIDDLE")
 
     words = len(words_list)
     endian_format = f">{words}I"
-    if GlobalConfig.ENDIAN == InputEndian.LITTLE:
+    if endian == InputEndian.LITTLE:
         endian_format = f"<{words}I"
     struct.pack_into(endian_format, buffer, 0, *words_list)
     return buffer
+
+def wordsToBytes(words_list: list[int], buffer: bytearray) -> bytearray:
+    return endianessWordsToBytes(GlobalConfig.ENDIAN, words_list, buffer)
 
 #! deprecated
 beWordsToBytes = wordsToBytes

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -111,7 +111,11 @@ def getRdataAndLateRodataForFunction(func: symbols.SymbolFunction, rodataFileLis
 def writeFunctionRodataToFile(f: TextIO, func: symbols.SymbolFunction, rdataList: list[symbols.SymbolBase], lateRodataList: list[symbols.SymbolBase], lateRodataSize: int):
     if len(rdataList) > 0:
         # Write the rdata
-        f.write(".section .rodata" + common.GlobalConfig.LINE_ENDS)
+        sectionName = ".rodata"
+        if common.GlobalConfig.COMPILER == common.Compiler.SN64:
+            sectionName = ".rdata"
+
+        f.write(f".section {sectionName}" + common.GlobalConfig.LINE_ENDS)
         for sym in rdataList:
             f.write(sym.disassemble())
             f.write(common.GlobalConfig.LINE_ENDS)

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -75,11 +75,11 @@ def getRdataAndLateRodataForFunctionFromSection(func: symbols.SymbolFunction, ro
 
         # We only care for rodata that's used once
         if rodataSym.contextSym.referenceCounter != 1:
-            break
+            continue
 
         # A const variable should not be placed with a function
         if rodataSym.contextSym.isMaybeConstVariable():
-            break
+            continue
 
         if rodataSym.contextSym.isLateRodata() and common.GlobalConfig.COMPILER == common.Compiler.IDO:
             lateRodataList.append(rodataSym)

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -14,8 +14,8 @@ from . import symbols
 
 
 class FileBase(common.ElementBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, sectionType: common.FileSectionType, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, 0, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), sectionType, segmentVromStart, overlayCategory)
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, words: list[int], sectionType: common.FileSectionType, segmentVromStart: int, overlayCategory: str|None):
+        super().__init__(context, vromStart, vromEnd, 0, vram, filename, words, sectionType, segmentVromStart, overlayCategory)
 
         self.symbolList: list[symbols.SymbolBase] = []
 
@@ -183,4 +183,4 @@ class FileBase(common.ElementBase):
 
 
 def createEmptyFile() -> FileBase:
-    return FileBase(common.Context(), 0, 0, 0, "", bytearray(), common.FileSectionType.Unknown, 0, None)
+    return FileBase(common.Context(), 0, 0, 0, "", [], common.FileSectionType.Unknown, 0, None)

--- a/spimdisasm/mips/MipsFileSplits.py
+++ b/spimdisasm/mips/MipsFileSplits.py
@@ -15,7 +15,7 @@ from . import FileBase, createEmptyFile
 
 class FileSplits(FileBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None, splitsData: common.FileSplitFormat|None=None, relocSection: sections.SectionRelocZ64|None=None):
-        super().__init__(context, vromStart, vromEnd, vram, filename, array_of_bytes, common.FileSectionType.Unknown, segmentVromStart, overlayCategory)
+        super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Unknown, segmentVromStart, overlayCategory)
 
         self.sectionsDict: dict[common.FileSectionType, dict[str, sections.SectionBase]] = {
             common.FileSectionType.Text: dict(),

--- a/spimdisasm/mips/sections/MipsSectionBss.py
+++ b/spimdisasm/mips/sections/MipsSectionBss.py
@@ -14,7 +14,7 @@ from . import SectionBase
 
 class SectionBss(SectionBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, bssVramStart: int, bssVramEnd: int, filename: str, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, bssVramStart, filename, bytearray(), common.FileSectionType.Bss, segmentVromStart, overlayCategory)
+        super().__init__(context, vromStart, vromEnd, bssVramStart, filename, [], common.FileSectionType.Bss, segmentVromStart, overlayCategory)
 
         self.bssVramStart: int = bssVramStart
         self.bssVramEnd: int = bssVramEnd

--- a/spimdisasm/mips/sections/MipsSectionData.py
+++ b/spimdisasm/mips/sections/MipsSectionData.py
@@ -37,12 +37,13 @@ class SectionData(SectionBase):
                     symbolList.append((localOffset, contextSym))
 
             if w >= self.vram and w > 0x80000000 and w < 0x84000000:
-                if self.getSymbol(w, tryPlusOffset=True, checkUpperLimit=True) is None:
-                    self.addPointerInDataReference(w)
+                if w not in self.context.bannedSymbols:
+                    if self.getSymbol(w, tryPlusOffset=True, checkUpperLimit=True) is None:
+                        self.addPointerInDataReference(w)
 
-                    if w < currentVram and self.containsVram(w):
-                        # References a data symbol from this section and it is behind this current symbol
-                        needsFurtherAnalyzis = True
+                        if w < currentVram and self.containsVram(w):
+                            # References a data symbol from this section and it is behind this current symbol
+                            needsFurtherAnalyzis = True
 
             localOffset += 4
 

--- a/spimdisasm/mips/sections/MipsSectionData.py
+++ b/spimdisasm/mips/sections/MipsSectionData.py
@@ -14,7 +14,11 @@ from . import SectionBase
 
 class SectionData(SectionBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, vram, filename, array_of_bytes, common.FileSectionType.Data, segmentVromStart, overlayCategory)
+        if common.GlobalConfig.ENDIAN_DATA is not None:
+            words = common.Utils.endianessBytesToWords(common.GlobalConfig.ENDIAN_DATA, array_of_bytes, vromStart, vromEnd)
+        else:
+            words = common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd)
+        super().__init__(context, vromStart, vromEnd, vram, filename, words, common.FileSectionType.Data, segmentVromStart, overlayCategory)
 
 
     def analyze(self):

--- a/spimdisasm/mips/sections/MipsSectionRelocZ64.py
+++ b/spimdisasm/mips/sections/MipsSectionRelocZ64.py
@@ -42,7 +42,7 @@ class RelocEntry:
 
 class SectionRelocZ64(SectionBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, vram, filename, array_of_bytes, common.FileSectionType.Reloc, segmentVromStart, overlayCategory)
+        super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Reloc, segmentVromStart, overlayCategory)
 
         self.seekup = self.words[-1]
 

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -16,7 +16,11 @@ from . import SectionBase
 
 class SectionRodata(SectionBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, vram, filename, array_of_bytes, common.FileSectionType.Rodata, segmentVromStart, overlayCategory)
+        if common.GlobalConfig.ENDIAN_RODATA is not None:
+            words = common.Utils.endianessBytesToWords(common.GlobalConfig.ENDIAN_RODATA, array_of_bytes, vromStart, vromEnd)
+        else:
+            words = common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd)
+        super().__init__(context, vromStart, vromEnd, vram, filename, words, common.FileSectionType.Rodata, segmentVromStart, overlayCategory)
 
         self.bytes: bytearray = bytearray(self.sizew*4)
         common.Utils.wordsToBytes(self.words, self.bytes)

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -25,6 +25,8 @@ class SectionRodata(SectionBase):
         self.bytes: bytearray = bytearray(self.sizew*4)
         common.Utils.wordsToBytes(self.words, self.bytes)
 
+        self.stringEncoding: str = "EUC-JP"
+
 
     def _stringGuesser(self, contextSym: common.ContextSymbol, localOffset: int) -> bool:
         if contextSym.isMaybeString or contextSym.isString():
@@ -41,7 +43,7 @@ class SectionRodata(SectionBase):
             return False
 
         try:
-            common.Utils.decodeString(self.bytes, localOffset)
+            common.Utils.decodeString(self.bytes, localOffset, self.stringEncoding)
         except (UnicodeDecodeError, RuntimeError):
             # String can't be decoded
             return False
@@ -148,6 +150,7 @@ class SectionRodata(SectionBase):
             sym = symbols.SymbolRodata(self.context, vrom, vromEnd, offset + self.inFileOffset, vram, words, self.segmentVromStart, self.overlayCategory)
             sym.parent = self
             sym.setCommentOffset(self.commentOffset)
+            sym.stringEncoding = self.stringEncoding
             sym.analyze()
             self.symbolList.append(sym)
 

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -17,7 +17,7 @@ from . import SectionBase
 
 class SectionText(SectionBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
-        super().__init__(context, vromStart, vromEnd, vram, filename, array_of_bytes, common.FileSectionType.Text, segmentVromStart, overlayCategory)
+        super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Text, segmentVromStart, overlayCategory)
 
         self.instrCat: rabbitizer.Enum = rabbitizer.InstrCategory.CPU
 

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -23,6 +23,8 @@ class SymbolBss(SymbolBase):
 
     def disassembleAsBss(self) -> str:
         output = self.getLabel()
+        if common.GlobalConfig.ASM_DATA_SYM_AS_LABEL:
+            output += f"{self.getName()}:" + common.GlobalConfig.LINE_ENDS
         output += self.generateAsmLineComment(0)
         output += f" .space 0x{self.spaceSize:02X}" + common.GlobalConfig.LINE_ENDS
         return output

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -131,7 +131,7 @@ class SymbolRodata(SymbolBase):
             if labelName:
                 label = labelName + common.GlobalConfig.LINE_ENDS
                 if common.GlobalConfig.ASM_DATA_SYM_AS_LABEL:
-                    label += f"{labelName}:" + common.GlobalConfig.LINE_ENDS
+                    label += f"{possibleSymbolName.getName()}:" + common.GlobalConfig.LINE_ENDS
 
         if len(self.context.relocSymbols[self.sectionType]) > 0:
             possibleReference = self.context.getRelocSymbol(self.inFileOffset + localOffset, self.sectionType)

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -16,6 +16,8 @@ class SymbolRodata(SymbolBase):
     def __init__(self, context: common.Context, vromStart: int, vromEnd: int, inFileOffset: int, vram: int, words: list[int], segmentVromStart: int, overlayCategory: str|None):
         super().__init__(context, vromStart, vromEnd, inFileOffset, vram, words, common.FileSectionType.Rodata, segmentVromStart, overlayCategory)
 
+        self.stringEncoding: str = "EUC-JP"
+
 
     def isString(self) -> bool:
         return self.contextSym.isString()
@@ -166,7 +168,7 @@ class SymbolRodata(SymbolBase):
                 try:
                     buffer = bytearray(4*len(self.words))
                     common.Utils.wordsToBytes(self.words, buffer)
-                    decodedStrings, rawStringSize = common.Utils.decodeString(buffer, 4*i)
+                    decodedStrings, rawStringSize = common.Utils.decodeString(buffer, 4*i, self.stringEncoding)
 
                     # dotType = ".asciz"
                     # value = f'"{decodedValue}"'


### PR DESCRIPTION
- Fixes data analyzis. It was ignoring banned symbols
- Use `.rdata` on rodata migration for SN64
- Fix `ASM_DATA_SYM_AS_LABEL` on bss generation
- Fix rodata symbols searching during migration
- Add option to disassemble data/rodata with different endianess than the global one
- Allow changing the string encoding per rodata segment
- Return the created segment by `addOverlaySegment`