### PR TITLE
1.5.7: Fix 0 size bss variables

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.5.6
+version = 1.5.7
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/singleFileDisasm.py
+++ b/singleFileDisasm.py
@@ -97,6 +97,8 @@ def disassemblerMain():
 
         start = int(args.start, 16)
         end = int(args.end, 16)
+        if end == 0xFFFFFF:
+            end = len(array_of_bytes)
         fileVram = int(args.vram, 16)
         endVram = fileVram + end - start
 

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 5, 6)
+__version_info__ = (1, 5, 7)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/mips/sections/MipsSectionBss.py
+++ b/spimdisasm/mips/sections/MipsSectionBss.py
@@ -53,11 +53,15 @@ class SectionBss(SectionBase):
             contextSym.sectionType = common.FileSectionType.Bss
 
             # Needs to move this to a list because the algorithm requires to check the size of a bss variable based on the next bss variable' vram
+            assert symbolVram < self.bssVramEnd
             bssSymbolOffsets.add(symbolVram - self.bssVramStart)
 
             # If the bss has an explicit size then produce an extra symbol after it, so the generated bss symbol uses the user-declared size
             if contextSym.size is not None:
-                bssSymbolOffsets.add(symbolVram + contextSym.size - self.bssVramStart)
+                newSymbolVram = symbolVram + contextSym.size
+                if newSymbolVram != self.bssVramEnd:
+                    assert newSymbolVram < self.bssVramEnd
+                    bssSymbolOffsets.add(symbolVram + contextSym.size - self.bssVramStart)
 
 
         sortedOffsets = sorted(bssSymbolOffsets)
@@ -73,6 +77,8 @@ class SectionBss(SectionBase):
                 nextSymbolOffset = sortedOffsets[i+1]
                 if nextSymbolOffset <= self.bssTotalSize:
                     space = nextSymbolOffset - symbolOffset
+
+            assert space > 0
 
             vrom = self.getVromOffset(symbolOffset)
             vromEnd = vrom + space


### PR DESCRIPTION
- Fixes an issue where 0 size bss variables where being outputted if the last bss variable of a file had a size which filled its size up until the file boundary