### PR TITLE
1.6.3: Speedup for overlay disassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install spimdisasm
 In case you want to mess with the latest development version without wanting to clone the repository, then you could use the following command:
 
 ```bash
+pip uninstall spimdisasm
 pip install git+https://github.com/Decompollaborate/spimdisasm.git@develop
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.6.3-dev
+version = 1.6.3
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = spimdisasm
-version = 1.6.2
+version = 1.6.3-dev
 author = Decompollaborate
 license = MIT
 description = N64 MIPS disassembler

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 6, 3)
-__version__ = ".".join(map(str, __version_info__))+ "-dev"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 6, 2)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 6, 3)
+__version__ = ".".join(map(str, __version_info__))+ "-dev"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -195,6 +195,10 @@ class ElementBase:
     def getSymbol(self, vramAddress: int, tryPlusOffset: bool = True, checkUpperLimit: bool = True, checkGlobalSegment: bool = True) -> ContextSymbol|None:
         "Searches symbol or a symbol with an addend if `tryPlusOffset` is True"
 
+        contextSym = self.context.globalSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
+        if contextSym is not None:
+            return contextSym
+
         if self.overlayCategory is not None:
             # If this element is part of an overlay segment
 
@@ -212,7 +216,8 @@ class ElementBase:
             for overlayCategory, segmentsPerVrom in self.context.overlaySegments.items():
                 if self.overlayCategory != overlayCategory:
                     for overlaySegment in segmentsPerVrom.values():
-                        # if overlaySegment.isVramInRange(vramAddress):
+                        if not overlaySegment.isVramInRange(vramAddress):
+                            continue
                         contextSym = overlaySegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
                         if contextSym is not None:
                             return contextSym
@@ -220,10 +225,6 @@ class ElementBase:
             if not checkGlobalSegment:
                 return None
 
-        # if self.context.globalSegment.isVramInRange(vramAddress):
-        contextSym = self.context.globalSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
-        if contextSym is not None:
-            return contextSym
         contextSym = self.context.unknownSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
         if self._ownSegmentReference is not None:
             if contextSym is not None and contextSym.vromAddress is not None:

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -197,7 +197,7 @@ class ElementBase:
     def getSymbol(self, vramAddress: int, tryPlusOffset: bool = True, checkUpperLimit: bool = True, checkGlobalSegment: bool = True) -> ContextSymbol|None:
         "Searches symbol or a symbol with an addend if `tryPlusOffset` is True"
 
-        if checkGlobalSegment:
+        if self.overlayCategory is None or checkGlobalSegment:
             contextSym = self.context.globalSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
             if contextSym is not None:
                 return contextSym

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -139,6 +139,12 @@ class ElementBase:
         return self.context.globalSegment
 
     def getSegmentForVram(self, vram: int) -> SymbolsSegment:
+        if self._ownSegmentReference is None:
+            if self.context.globalSegment.isVromInRange(self.vromStart):
+                self._ownSegmentReference = self.context.globalSegment
+        if self.context.globalSegment.isVramInRange(vram):
+            return self.context.globalSegment
+
         if self.overlayCategory is not None:
             # If this element is part of an overlay segment
 
@@ -153,14 +159,15 @@ class ElementBase:
                     if overlaySegment.isVramInRange(vram):
                         return overlaySegment
 
-        if self._ownSegmentReference is None:
-            if self.context.globalSegment.isVromInRange(self.vromStart):
-                self._ownSegmentReference = self.context.globalSegment
-        if self.context.globalSegment.isVramInRange(vram):
-            return self.context.globalSegment
         return self.context.unknownSegment
 
     def getSegmentForVrom(self, vrom: int) -> SymbolsSegment:
+        if self._ownSegmentReference is None:
+            if self.context.globalSegment.isVromInRange(self.vromStart):
+                self._ownSegmentReference = self.context.globalSegment
+        if self.context.globalSegment.isVromInRange(vrom):
+            return self.context.globalSegment
+
         if self.overlayCategory is not None:
             # If this element is part of an overlay segment
 
@@ -184,20 +191,16 @@ class ElementBase:
                         if overlaySegment.isVromInRange(vrom):
                             return overlaySegment
 
-        if self._ownSegmentReference is None:
-            if self.context.globalSegment.isVromInRange(self.vromStart):
-                self._ownSegmentReference = self.context.globalSegment
-        if self.context.globalSegment.isVromInRange(vrom):
-            return self.context.globalSegment
         return self.context.unknownSegment
 
 
     def getSymbol(self, vramAddress: int, tryPlusOffset: bool = True, checkUpperLimit: bool = True, checkGlobalSegment: bool = True) -> ContextSymbol|None:
         "Searches symbol or a symbol with an addend if `tryPlusOffset` is True"
 
-        contextSym = self.context.globalSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
-        if contextSym is not None:
-            return contextSym
+        if checkGlobalSegment:
+            contextSym = self.context.globalSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
+            if contextSym is not None:
+                return contextSym
 
         if self.overlayCategory is not None:
             # If this element is part of an overlay segment
@@ -222,8 +225,8 @@ class ElementBase:
                         if contextSym is not None:
                             return contextSym
 
-            if not checkGlobalSegment:
-                return None
+        if not checkGlobalSegment:
+            return None
 
         contextSym = self.context.unknownSegment.getSymbol(vramAddress, tryPlusOffset=tryPlusOffset, checkUpperLimit=checkUpperLimit)
         if self._ownSegmentReference is not None:


### PR DESCRIPTION
- Moves the `globalSegment` check above all the other checks in `getSymbol`, providing a faster lookup since most of the time overlays usually reference a symbol from the `globalSegment` over a symbol from another overlay segment from a different category 