### PR TITLE
Check followed bytes for word-aligned strings

### DIFF
--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -51,6 +51,13 @@ class SectionRodata(SectionBase):
             if otherSym != contextSym:
                 return False
 
+            # To be a valid aligned string, the next word-aligned bytes needs to be zero
+            checkStartOffset = localOffset + rawStringSize
+            checkEndOffset = min(checkStartOffset + ((checkStartOffset + 3) % 4) + 1, len(self.bytes))
+            while checkStartOffset < checkEndOffset:
+                if self.bytes[checkStartOffset] != 0:
+                    return False
+                checkStartOffset += 1
         except (UnicodeDecodeError, RuntimeError):
             # String can't be decoded
             return False

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -53,7 +53,7 @@ class SectionRodata(SectionBase):
 
             # To be a valid aligned string, the next word-aligned bytes needs to be zero
             checkStartOffset = localOffset + rawStringSize
-            checkEndOffset = min(checkStartOffset + ((checkStartOffset + 3) % 4) + 1, len(self.bytes))
+            checkEndOffset = min((checkStartOffset + 3) & ~3, len(self.bytes))
             while checkStartOffset < checkEndOffset:
                 if self.bytes[checkStartOffset] != 0:
                     return False

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -140,11 +140,15 @@ class SymbolBase(common.ElementBase):
                             label += f"{contextSym.getName()}:" + common.GlobalConfig.LINE_ENDS
 
             if isByte:
-                shiftValue = 24 - (j * 8)
+                shiftValue = j * 8
+                if common.GlobalConfig.ENDIAN == common.InputEndian.BIG:
+                    shiftValue = 24 - shiftValue
                 subVal = (w & (0xFF << shiftValue)) >> shiftValue
                 value = f"0x{subVal:02X}"
             elif isShort:
-                shiftValue = 16 - (j * 8)
+                shiftValue = j * 8
+                if common.GlobalConfig.ENDIAN == common.InputEndian.BIG:
+                    shiftValue = 16 - shiftValue
                 subVal = (w & (0xFFFF << shiftValue)) >> shiftValue
                 value = f"0x{subVal:04X}"
             else:


### PR DESCRIPTION
There are some fake string detected that issue a `.balign 4`. That would be fine if the next aligned word would just contain zeroes, but often that is not the case. This PR performs that check, effectively discarding the string. This might also come at the advantage to prevent false strings to be disassembled.