### PR TITLE
1.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.9.0"
+version = "1.9.1"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 9, 0)
+__version_info__ = (1, 9, 1)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -106,6 +106,11 @@ class SymbolRodata(SymbolBase):
                 count += 1
         return count
 
+    def getPrevAlignDirective(self, i: int=0) -> str:
+        if self.isJumpTable():
+            if i == 0 and common.GlobalConfig.COMPILER != common.Compiler.IDO:
+                return f".align 3{common.GlobalConfig.LINE_ENDS}"
+        return super().getPrevAlignDirective(i)
 
     def getNthWord(self, i: int, canReferenceSymbolsWithAddends: bool=False, canReferenceConstants: bool=False) -> tuple[str, int]:
         localOffset = 4*i


### PR DESCRIPTION
- Emit a `.align 3` directive for every jumptable on non-IDO compilers