### PR TITLE
1.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ Check `spimdisasm/__main__.py` for a minimal disassembly working example on how 
 ## References
 
 - <https://techpubs.jurassic.nl/manuals/0620/developer/Cplr_PTG/sgi_html/apa.html>
+- <http://www.iquebrew.org/index.php?title=IO>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.10.3"
+version = "1.10.4.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 10, 3)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 10, 4)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__main__.py
+++ b/spimdisasm/__main__.py
@@ -41,11 +41,8 @@ def exampleMain():
     end = int(args.end, 16)
     fileVram = int(args.vram, 16)
 
-    # Truncate binary to the requested range
-    truncatedInputBytes = array_of_bytes[start:end]
-
     # Asume the input is a .text section. Insntance a SectionText and analyze it
-    textSection = spimdisasm.mips.sections.SectionText(context, start, end, fileVram, inputPath.stem, truncatedInputBytes, 0, None)
+    textSection = spimdisasm.mips.sections.SectionText(context, start, end, fileVram, inputPath.stem, array_of_bytes, 0, None)
     textSection.analyze()
     textSection.setCommentOffset(start)
 

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -34,7 +34,7 @@ class InputEndian(enum.Enum):
         raise ValueError(f"No struct format string available for : {self}")
 
 
-compilerOptions = {"IDO", "GCC", "SN64", "PSYQ"}
+compilerOptions = {"IDO", "GCC", "SN64", "PSYQ", "EGCS"}
 
 @enum.unique
 class Compiler(enum.Enum):
@@ -43,6 +43,7 @@ class Compiler(enum.Enum):
     GCC = "GCC"
     SN64 = "SN64"
     PSYQ = "PSYQ"
+    EGCS = "EGCS"
 
     @staticmethod
     def fromStr(value: str) -> Compiler:

--- a/spimdisasm/common/SymbolsSegment.py
+++ b/spimdisasm/common/SymbolsSegment.py
@@ -247,6 +247,14 @@ class SymbolsSegment:
         0xA4300004: "MI_VERSION_REG",
         0xA4300008: "MI_INTR_REG",
         0xA430000C: "MI_INTR_MASK_REG",
+        0xA4300010: "D_A4300010",
+        0xA4300014: "MI_SK_EXCEPTION_REG",
+        0xA4300018: "MI_SK_WATCHDOG_TIMER",
+        0xA4300028: "D_A4300028",
+        0xA430002C: "MI_RANDOM_BIT",
+        0xA4300030: "D_A4300030",
+        0xA4300038: "MI_HW_INTR_REG",
+        0xA430003C: "MI_HW_INTR_MASK_REG",
 
         # Video Interface Registers
         0xA4400000: "VI_STATUS_REG", # VI_STATUS_REG / VI_CONTROL_REG
@@ -275,9 +283,6 @@ class SymbolsSegment:
         # Peripheral/Parallel Interface Registers
         0xA4600000: "PI_DRAM_ADDR_REG",
         0xA4600004: "PI_CART_ADDR_REG",
-        0xA4600005: "D_A4600005", # TODO: figure out its name
-        0xA4600006: "D_A4600006", # TODO: figure out its name
-        0xA4600007: "D_A4600007", # TODO: figure out its name
         0xA4600008: "PI_RD_LEN_REG",
         0xA460000C: "PI_WR_LEN_REG",
         0xA4600010: "PI_STATUS_REG",
@@ -289,6 +294,28 @@ class SymbolsSegment:
         0xA4600028: "PI_BSD_DOM2_LWD_REG", # PI dom2 pulse width
         0xA460002C: "PI_BSD_DOM2_PGS_REG", # PI dom2 page size
         0xA4600030: "PI_BSD_DOM2_RLS_REG", # PI dom2 release
+        0xA4600038: "PI_CARD_STATUS_REG",
+        0xA4600040: "PI_ATB_NEXT_CONFIG",
+        0xA4600044: "D_A4600044",
+        0xA4600048: "PI_CARD_CNT_REG",
+        0xA460004C: "PI_CARD_CONFIG_REG",
+        0xA4600050: "PI_AES_CNT",
+        0xA4600054: "PI_ALLOWED_IO",
+        0xA4600058: "PI_EX_RD_LEN_REG",
+        0xA460005C: "PI_EX_WR_LEN_REG",
+        0xA4600060: "PI_MISC_REG",
+        0xA4600070: "PI_CARD_BLK_OFFSET_REG",
+        0xA4610000: "PI_EX_DMA_BUF",
+        0xA4610420: "PI_AES_EXPANDED_KEY",
+        0xA46104D0: "PI_AES_IV",
+        0xA4610500: "PI_ATB_ENTRY",
+        0xA4620000: "D_A4620000",
+        0xA46E0000: "PI_RDB_REQ_HI_REG",
+        0xA46E0002: "PI_RDB_REQ_LO_REG",
+        0xA46E0004: "D_A46E0004",
+        0xA46E0400: "D_A46E0400",
+        0xA46E0402: "D_A46E0402",
+        0xA46E8000: "PI_RDB_STATUS_REG",
 
         # RDRAM Interface Registers
         0xA4700000: "RI_MODE_REG",
@@ -308,6 +335,11 @@ class SymbolsSegment:
         0xA4800010: "SI_PIF_ADDR_WR64B_REG",
         0xA4800014: "D_A4800014", # reserved
         0xA4800018: "SI_STATUS_REG",
+
+        0xA4900000: "D_A4900000",
+        0xA4940010: "USB0_STATUS_REG",
+        0xA4A00000: "D_A4A00000",
+        0xA4A40010: "USB1_STATUS_REG",
     }
     "N64 OS hardware registers"
 

--- a/spimdisasm/common/SymbolsSegment.py
+++ b/spimdisasm/common/SymbolsSegment.py
@@ -194,6 +194,23 @@ class SymbolsSegment:
         0x80000314: ("osVersion",      "u32", 0x4),
         0x80000318: ("osMemSize",      "u32", 0x4),
         0x8000031C: ("osAppNMIBuffer", "u8",  0x40),
+
+        # iQue specific symbols
+        0x8000035c: ("__osBbEepromAddress", "u32", 0x4),
+        0x80000360: ("__osBbEepromSize", "u32", 0x4),
+        0x80000364: ("__osBbFlashAddress", "u32", 0x4),
+        0x80000368: ("__osBbFlashSize", "u32", 0x4),
+        0x8000036c: ("__osBbSramAddress", "u32", 0x4),
+        0x80000370: ("__osBbSramSize", "u32", 0x4),
+        0x80000374: ("__osBbPakAddress", "u32", 0x4 * 4),
+        0x80000384: ("__osBbPakSize", "u32", 0x4),
+        0x80000388: ("__osBbIsBb", "u32", 0x4),
+        0x8000038c: ("__osBbHackFlags", "u32", 0x4),
+        0x80000390: ("__osBbStashMagic", "u32", 0x4),
+        0x80000394: ("__osBbPakBindings", "s32", 0x4 * 4),
+        0x800003a4: ("__osBbStateName", "char", 0x10),
+        0x800003b4: ("__osBbStateDirty", "u32", 0x4),
+        0x800003b8: ("__osBbAuxDataLimit", "u32", 0x4),
     }
 
     N64HardwareRegs = {

--- a/spimdisasm/disasmdis/DisasmdisInternals.py
+++ b/spimdisasm/disasmdis/DisasmdisInternals.py
@@ -17,7 +17,7 @@ def getArgsParser() -> argparse.ArgumentParser:
     description = "CLI tool to disassemble multiples instructions passed as argument"
     parser = argparse.ArgumentParser(description=description)
 
-    parser.add_argument("input", help="Hex words to be disassembled. Leading '0x' must be omitted", nargs='?')
+    parser.add_argument("input", help="Hex words to be disassembled. Leading '0x' must be omitted", nargs='+')
 
     parser.add_argument("--endian", help="Set the endianness of input files. Defaults to 'big'", choices=["big", "little", "middle"], default="big")
     parser.add_argument("--category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r5900"])

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -41,6 +41,9 @@ class SectionText(SectionBase):
 
 
     def _findFunctions(self, instrsList: list[rabbitizer.Instruction]):
+        if len(instrsList) == 0:
+            return [0], [False]
+
         functionEnded = False
         farthestBranch = 0
         funcsStartsList = [0]
@@ -55,6 +58,30 @@ class SectionText(SectionBase):
         isInstrImplemented = True
         index = 0
         nInstr = len(instrsList)
+
+        if instrsList[0].isNop():
+            isboundary = False
+            # Loop over until we find a instruction that isn't a nop
+            while index < nInstr:
+                if currentFunctionSym is not None:
+                    break
+
+                instr = instrsList[index]
+                if not instr.isNop():
+                    if isboundary:
+                        self.fileBoundaries.append(self.inFileOffset + index*4)
+                    break
+                index += 1
+                instructionOffset += 4
+                isboundary |= ((instructionOffset % 16) == 0)
+
+                currentInstructionStart = instructionOffset
+                currentFunctionSym = self.getSymbol(self.getVramOffset(instructionOffset), tryPlusOffset=False, checkGlobalSegment=False)
+
+            if index != 0:
+                funcsStartsList.append(index)
+                unimplementedInstructionsFuncList.append(not isInstrImplemented)
+
         while index < nInstr:
             instr = instrsList[index]
             if not instr.isImplemented():
@@ -66,9 +93,15 @@ class SectionText(SectionBase):
                 isLikelyHandwritten = self.isHandwritten
                 index += 1
                 instructionOffset += 4
+
+                auxSym = self.getSymbol(self.getVramOffset(instructionOffset), tryPlusOffset=False, checkGlobalSegment=False)
+
                 isboundary = False
                 # Loop over until we find a instruction that isn't a nop
                 while index < nInstr:
+                    if auxSym is not None:
+                        break
+
                     instr = instrsList[index]
                     if not instr.isNop():
                         if isboundary:
@@ -76,10 +109,12 @@ class SectionText(SectionBase):
                         break
                     index += 1
                     instructionOffset += 4
-                    isboundary = True
+                    isboundary |= ((instructionOffset % 16) == 0)
+
+                    auxSym = self.getSymbol(self.getVramOffset(instructionOffset), tryPlusOffset=False, checkGlobalSegment=False)
 
                 currentInstructionStart = instructionOffset
-                currentFunctionSym = self.getSymbol(self.getVramOffset(instructionOffset), tryPlusOffset=False, checkGlobalSegment=False)
+                currentFunctionSym = auxSym
 
                 funcsStartsList.append(index)
                 unimplementedInstructionsFuncList.append(not isInstrImplemented)

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -101,11 +101,14 @@ class SectionText(SectionBase):
                 if branchOffset < 0:
                     if branchOffset + instructionOffset < 0:
                         # Whatever we are reading is not a valid instruction
-                        break
+                        if not instr.isJump(): # Make an exception for `j`
+                            break
                     # make sure to not branch outside of the current function
                     if not isLikelyHandwritten:
                         j = len(funcsStartsList) - 1
                         while j >= 0:
+                            if branchOffset + instructionOffset < 0:
+                                break
                             if (branchOffset + instructionOffset) < funcsStartsList[j] * 4:
                                 vram = self.getVramOffset(funcsStartsList[j]*4)
                                 funcSymbol = self.getSymbol(vram, tryPlusOffset=False, checkGlobalSegment=False)

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -185,7 +185,7 @@ class InstrAnalyzer:
                 # IDO does not pair multiples %hi to the same %lo
                 return self.symbolLoInstrOffset[lowerOffset]
 
-            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.SN64, common.Compiler.PSYQ}:
+            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS}:
                 if luiOffset is None or hiValue is None:
                     return None
 


### PR DESCRIPTION
- Avoid trashing function analysis for `j` jumps outside of the function
- Add `EGCS` compiler
- `nop`s at the beginning of the files are now skipped.
- Fix `disasmdis` not properly accepting spaces
- Add iQue-specific libultra syms and hardware regs
- Add `--data-start` and `--data-end` flags to `singleFileDisasm`