### PR TITLE
1.10.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.10.5"
+version = "1.10.6.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.10.6.dev0"
+version = "1.10.6"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 10, 6)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 10, 5)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 10, 6)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/Context.py
+++ b/spimdisasm/common/Context.py
@@ -59,6 +59,10 @@ class Context:
 
 
     def changeGlobalSegmentRanges(self, vromStart: int, vromEnd: int, vramStart: int, vramEnd: int):
+        if vromStart == vromEnd:
+            Utils.eprint(f"Warning: globalSegment's will has its vromStart equal to the vromEnd (0x{vromStart:X})")
+        if vramStart == vramEnd:
+            Utils.eprint(f"Warning: globalSegment's will has its vramStart equal to the vramEnd (0x{vramStart:X})")
         self.globalSegment.changeRanges(vromStart, vromEnd, vramStart, vramEnd)
         if self._defaultVramRanges:
             self.totalVramStart = vramStart

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -255,6 +255,9 @@ class ContextSymbol:
         # if self.referenceCounter > 1: return False # ?
         return self.isJumpTable() or self.isFloat() or self.isDouble()
 
+    def hasUserDeclaredSize(self) -> bool:
+        return self.size is not None
+
 
     def getDefaultName(self) -> str:
         suffix = ""

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -191,6 +191,8 @@ class GlobalConfig:
 
     LINE_ENDS: str = "\n"
 
+    PANIC_RANGE_CHECK: bool = False
+    """Produce a fatal error if a range check fails instead of just printing a warning"""
 
     QUIET: bool = False
     VERBOSE: bool = False
@@ -268,6 +270,8 @@ class GlobalConfig:
 
         miscConfig.add_argument("--use-dot-byte", help=f"Disassemble symbols marked as bytes with .byte instead of .word. Defaults to {GlobalConfig.USE_DOT_BYTE}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--use-dot-short", help=f"Disassemble symbols marked as shorts with .short instead of .word. Defaults to {GlobalConfig.USE_DOT_SHORT}", action=Utils.BooleanOptionalAction)
+
+        miscConfig.add_argument("--panic-range-check", help=f"Produce a fatal error if a range check fails instead of just printing a warning. Defaults to {GlobalConfig.PANIC_RANGE_CHECK}", action=Utils.BooleanOptionalAction)
 
 
         verbosityConfig = parser.add_argument_group("Verbosity options")
@@ -414,6 +418,9 @@ class GlobalConfig:
             GlobalConfig.USE_DOT_BYTE = args.use_dot_byte
         if args.use_dot_short is not None:
             GlobalConfig.USE_DOT_SHORT = args.use_dot_short
+
+        if args.panic_range_check is not None:
+            GlobalConfig.PANIC_RANGE_CHECK = args.panic_range_check
 
 
         if args.verbose is not None:

--- a/spimdisasm/common/SymbolsSegment.py
+++ b/spimdisasm/common/SymbolsSegment.py
@@ -21,7 +21,7 @@ class SymbolsSegment:
     def __init__(self, context: "Context", vromStart: int|None, vromEnd: int|None, vramStart: int, vramEnd: int, overlayCategory: str|None=None):
         assert vramStart < vramEnd
         if vromStart is not None and vromEnd is not None:
-            assert vromStart < vromEnd
+            assert vromStart <= vromEnd, f"0x{vromStart:X} <= 0x{vromEnd:X}"
 
         self.vromStart: int|None = vromStart
         self.vromEnd: int|None = vromEnd
@@ -67,8 +67,8 @@ class SymbolsSegment:
         return self.vramStart <= vram < self.vramEnd
 
     def changeRanges(self, vromStart: int, vromEnd: int, vramStart: int, vramEnd: int) -> None:
-        assert vromStart < vromEnd
-        assert vramStart < vramEnd
+        assert vromStart <= vromEnd, f"0x{vromStart:X} <= 0x{vromEnd:X}"
+        assert vramStart <= vramEnd, f"0x{vramStart:X} <= 0x{vramEnd:X}"
 
         self.vromStart = vromStart
         self.vromEnd = vromEnd

--- a/spimdisasm/common/SymbolsSegment.py
+++ b/spimdisasm/common/SymbolsSegment.py
@@ -367,6 +367,13 @@ class SymbolsSegment:
             contextSym.isDefined = True
             contextSym.isUserDeclared = True
 
+            if useRealNames:
+                contextSym = self.addConstant(vram, name)
+                contextSym.type = SymbolSpecialType.hardwarereg
+                contextSym.size = 4
+                contextSym.isDefined = True
+                contextSym.isUserDeclared = True
+
 
     def readVariablesCsv(self, filepath: Path):
         if not filepath.exists():

--- a/spimdisasm/elf32/Elf32Constants.py
+++ b/spimdisasm/elf32/Elf32Constants.py
@@ -70,6 +70,7 @@ class Elf32HeaderFlag(enum.Enum):
     ABI2            = 0x00000020
     ABI_ON32        = 0x00000040
 
+    _32BITSMODE     = 0x00000100
     FP64            = 0x00000200 # Uses FP64 (12 callee-saved).
     NAN2008         = 0x00000400 # Uses IEEE 754-2008 NaN encoding.
 
@@ -93,7 +94,7 @@ class Elf32HeaderFlag(enum.Enum):
             Elf32HeaderFlag.NOREORDER, Elf32HeaderFlag.PIC, Elf32HeaderFlag.CPIC,
             Elf32HeaderFlag.XGOT, Elf32HeaderFlag.F_64BIT_WHIRL, Elf32HeaderFlag.ABI2,
             Elf32HeaderFlag.ABI_ON32,
-            Elf32HeaderFlag.FP64, Elf32HeaderFlag.NAN2008}
+            Elf32HeaderFlag._32BITSMODE, Elf32HeaderFlag.FP64, Elf32HeaderFlag.NAN2008}
         parsedFlags: list[Elf32HeaderFlag] = list()
 
         for flagEnum in flagsToCheck:

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -95,6 +95,10 @@ class Elf32File:
             common.Utils.eprint(f"Warning: Elf with ABI_ON32 flag.")
             common.Utils.eprint(f"\t This flag is currently not handled in any way, please report this")
 
+        if Elf32HeaderFlag._32BITSMODE in self.elfFlags:
+            common.Utils.eprint(f"Warning: Elf with 32BITSMODE flag.")
+            common.Utils.eprint(f"\t This flag is currently not handled in any way, please report this")
+
         if Elf32HeaderFlag.FP64 in self.elfFlags:
             common.Utils.eprint(f"Warning: Elf with FP64 flag.")
             common.Utils.eprint(f"\t This flag is currently not handled in any way, please report this")
@@ -356,7 +360,10 @@ class Elf32File:
 
         print(f"  {'Flags:':<34} 0x{self.header.flags:X}", end="")
         for flag in self.elfFlags:
-            print(f", {flag.name.lower().replace('arch_', 'mips')}", end="")
+            printableFlagName = flag.name.lower().replace('arch_', 'mips')
+            if len(printableFlagName) > 0 and printableFlagName[0] == "_":
+                printableFlagName = printableFlagName[1:]
+            print(f", {printableFlagName}", end="")
         if self.unknownElfFlags != 0:
             print(f", 0x{self.unknownElfFlags:08X}", end="")
         print()

--- a/spimdisasm/mips/sections/MipsSectionBss.py
+++ b/spimdisasm/mips/sections/MipsSectionBss.py
@@ -58,12 +58,12 @@ class SectionBss(SectionBase):
             bssSymbolOffsets.add(symbolVram - self.bssVramStart)
 
             # If the bss has an explicit size then produce an extra symbol after it, so the generated bss symbol uses the user-declared size
-            if contextSym.size is not None:
-                newSymbolVram = symbolVram + contextSym.size
+            if contextSym.hasUserDeclaredSize():
+                newSymbolVram = symbolVram + contextSym.getSize()
                 if newSymbolVram != self.bssVramEnd:
                     assert newSymbolVram >= self.bssVramStart
                     assert newSymbolVram < self.bssVramEnd, f"{self.name}, symbolVram={symbolVram:X}, newSymbolVram={newSymbolVram:X}, self.bssVramEnd={self.bssVramEnd:X}"
-                    symOffset = symbolVram + contextSym.size - self.bssVramStart
+                    symOffset = symbolVram + contextSym.getSize() - self.bssVramStart
                     bssSymbolOffsets.add(symOffset)
                     autoCreatedPads.add(symOffset)
 

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -202,6 +202,8 @@ class SectionText(SectionBase):
 
         funcsStartsList, unimplementedInstructionsFuncList = self._findFunctions(instrsList)
 
+        previousSymbolExtraPadding = 0
+
         i = 0
         startsCount = len(funcsStartsList)
         for startIndex in range(startsCount):
@@ -236,6 +238,15 @@ class SectionText(SectionBase):
             func.isRsp = self.instrCat == rabbitizer.InstrCategory.RSP
             func.analyze()
             self.symbolList.append(func)
+
+            # File boundaries detection
+            if func.inFileOffset % 16 == 0:
+                # Files are always 0x10 aligned
+
+                if previousSymbolExtraPadding > 0:
+                    self.fileBoundaries.append(func.inFileOffset)
+
+            previousSymbolExtraPadding = func.countExtraPadding()
             i += 1
 
 

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -24,7 +24,7 @@ class SymbolBss(SymbolBase):
     def analyze(self):
         super().analyze()
 
-        if self.contextSym.size is not None:
+        if self.contextSym.hasUserDeclaredSize():
             # Check user declared size matches the size that will be generated
             contextSymSize = self.contextSym.getSize()
             if self.spaceSize != contextSymSize:

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -21,6 +21,19 @@ class SymbolBss(SymbolBase):
     def sizew(self) -> int:
         return self.spaceSize // 4
 
+    def analyze(self):
+        super().analyze()
+
+        if self.contextSym.size is not None:
+            # Check user declared size matches the size that will be generated
+            contextSymSize = self.contextSym.getSize()
+            if self.spaceSize != contextSymSize:
+                warningMessage = f"Range check triggered: .bss symbol (name: {self.contextSym.getName()}, address: 0x{self.contextSym.vram:X}): User declared size (0x{contextSymSize:X}) does not match the .space that will be generated (0x{self.spaceSize:X}). Try checking the size again or look for symbols which overlaps this region"
+                if common.GlobalConfig.PANIC_RANGE_CHECK:
+                    assert self.spaceSize == contextSymSize, warningMessage
+                else:
+                    common.Utils.eprint(f"\n\n{warningMessage}\n")
+
     def disassembleAsBss(self, useGlobalLabel: bool=True) -> str:
         output = self.getReferenceeSymbols()
         output += self.getPrevAlignDirective(0)

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -385,8 +385,8 @@ class SymbolFunction(SymbolText):
             instr = self.instructions[i]
             nextInstr = self.instructions[i-1]
 
-            if nextInstr.isJump():
-                return count - 1
+            if nextInstr.hasDelaySlot():
+                return count
 
             if not instr.isNop():
                 return count

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -385,8 +385,8 @@ class SymbolFunction(SymbolText):
             instr = self.instructions[i]
             nextInstr = self.instructions[i-1]
 
-            if nextInstr.uniqueId == rabbitizer.InstrId.cpu_jr:
-                return count
+            if nextInstr.isJump():
+                return count - 1
 
             if not instr.isNop():
                 return count

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -86,6 +86,10 @@ class SymbolRodata(SymbolBase):
 
 
     def countExtraPadding(self) -> int:
+        if self.contextSym.hasUserDeclaredSize():
+            if self.sizew * 4 == self.contextSym.getSize():
+                return 0
+
         count = 0
         if self.isString():
             for i in range(len(self.words)-1, 0, -1):


### PR DESCRIPTION
- Fix some `.text` boundaries not being properly detected.
- Add hardware registers as constants so they are used by `lui`/`ori` pairs
- Check for bss symbol size to match user declared size
- Warn if the globalsegment vrom start and end is the same
- Identify 32bitsmode elf flag
- Avoid reporting leading zeroes as padding in rodata symbols if the size of the symbol matches the user declared one