### PR TITLE
1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ This repo can be used either by using the existing front-end scripts or by creat
 
 ### Front-end
 
-Every front-end submodule has its own `--help` screen.
+Every front-end CLI tool has its own `--help` screen.
 
-The submodules can be executed with `python3 -m spimdisasm.modulename`, for example `python3 -m spimdisasm.disasmdis`
+The included tool can be executed with either `spimdisasm modulename` (for example `spimdisasm disasmdis --help`) or directly `modulename` (for example `spimdisasm --help`)
 
 - `singleFileDisasm`: Allows to disassemble a single binary file, producing matching assembly files.
 
 - `disasmdis`: Disassembles raw hex passed to the CLI as a MIPS instruction.
 
-- `elfObjDisasm`: \[EXPERIMENTAL\] Allows to disassemble `.o` elf files. Generated assembly files are not guaranteed to match or be assemblable.
+- `elfObjDisasm`: \[EXPERIMENTAL\] Allows to disassemble elf files. Generated assembly files are not guaranteed to match or even be assemblable.
 
 - `rspDisasm`: Disassemblies RSP binaries.
 
@@ -85,7 +85,7 @@ The submodules can be executed with `python3 -m spimdisasm.modulename`, for exam
 
 TODO
 
-Check `spimdisasm/__main__.py` for a minimal disassembly working example on how to use the API. Checking the front-ends is recommended too.
+Check the already existing front-ends is recommended for now.
 
 ## References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.10.7.dev0"
+version = "1.11.0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.10.6"
+version = "1.10.7.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ dynamic = ["dependencies"]
 requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project.scripts]
+singleFileDisasm = "spimdisasm.singleFileDisasm:disassemblerMain"
+disasmdis = "spimdisasm.disasmdis:disasmdisMain"
+elfObjDisasm = "spimdisasm.elfObjDisasm:elfObjDisasmMain"
+rspDisasm = "spimdisasm.rspDisasm:rspDisasmMain"
+
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["build*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
+spimdisasm = "spimdisasm.frontendCommon.FrontendUtilities:cliMain"
 singleFileDisasm = "spimdisasm.singleFileDisasm:disassemblerMain"
 disasmdis = "spimdisasm.disasmdis:disasmdisMain"
 elfObjDisasm = "spimdisasm.elfObjDisasm:elfObjDisasmMain"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 10, 6)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 10, 7)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 10, 7)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version_info__ = (1, 11, 0)
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__main__.py
+++ b/spimdisasm/__main__.py
@@ -5,50 +5,8 @@
 
 from __future__ import annotations
 
-import argparse
-import pathlib
-
 import spimdisasm
 
 
-def exampleMain():
-    description = "Single file disassembler example"
-    parser = argparse.ArgumentParser(prog="spimdisasm", description=description)
-
-    parser.add_argument("binary", help="Path to input binary")
-
-    parser.add_argument("--output", help="Path to output. Use '-' to print to stdout instead. Defaults to '-'", default="-")
-
-    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {spimdisasm.__version__}")
-
-    parser_singleFile = parser.add_argument_group("Single file disassembly options")
-
-    parser_singleFile.add_argument("--start", help="Raw offset of the input binary file to start disassembling. Expects an hex value", default="0")
-    parser_singleFile.add_argument("--end", help="Offset end of the input binary file to start disassembling. Expects an hex value",  default="0xFFFFFF")
-    parser_singleFile.add_argument("--vram", help="Set the VRAM address. Expects an hex value", default="0x0")
-
-    args = parser.parse_args()
-
-    # Context is used to store information that should be shared between file sections, such as mapping the symbol vram's to its name and more
-    context = spimdisasm.common.Context()
-    context.changeGlobalSegmentRanges(0x0, 0xFFFFFFFF, 0x0, 0xFFFFFFFF)
-
-    # Read whole binary input file
-    inputPath = pathlib.Path(args.binary)
-    array_of_bytes = spimdisasm.common.Utils.readFileAsBytearray(inputPath)
-
-    start = int(args.start, 16)
-    end = int(args.end, 16)
-    fileVram = int(args.vram, 16)
-
-    # Asume the input is a .text section. Insntance a SectionText and analyze it
-    textSection = spimdisasm.mips.sections.SectionText(context, start, end, fileVram, inputPath.stem, array_of_bytes, 0, None)
-    textSection.analyze()
-    textSection.setCommentOffset(start)
-
-    # Write the processed section to a file. This method handles '-' to stdout too
-    textSection.saveToFile(args.output)
-
-
 if __name__ == "__main__":
-    exampleMain()
+    exit(spimdisasm.frontendCommon.FrontendUtilities.cliMain())

--- a/spimdisasm/common/Context.py
+++ b/spimdisasm/common/Context.py
@@ -103,6 +103,11 @@ class Context:
     def fillDefaultBannedSymbols(self):
         self.bannedSymbols |= self.N64DefaultBanned
 
+
+    def isAddressInGlobalRange(self, address: int) -> bool:
+        return self.totalVramStart <= address < self.totalVramEnd
+
+
     def addBannedSymbol(self, address: int):
         self.bannedSymbols.add(address)
 

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -96,6 +96,11 @@ class ArchLevel(OrderedEnum):
             return None
 
 
+class InputFileType(enum.Enum):
+    BINARY = "binary"
+    ELF = "elf"
+
+
 class GlobalConfig:
     DISASSEMBLE_UNKNOWN_INSTRUCTIONS: bool = False
     """Try to disassemble non implemented instructions and functions"""
@@ -137,6 +142,8 @@ class GlobalConfig:
     """
 
     ARCHLEVEL: ArchLevel = ArchLevel.MIPS3
+
+    INPUT_FILE_TYPE: InputFileType = InputFileType.BINARY
 
     GP_VALUE: int|None = None
     """Value used for $gp relocation loads and stores"""

--- a/spimdisasm/common/__init__.py
+++ b/spimdisasm/common/__init__.py
@@ -4,7 +4,7 @@
 from . import Utils
 
 from .SortedDict import SortedDict
-from .GlobalConfig import GlobalConfig, InputEndian, Compiler, Abi, ArchLevel
+from .GlobalConfig import GlobalConfig, InputEndian, Compiler, Abi, ArchLevel, InputFileType
 from .FileSectionType import FileSectionType, FileSections_ListBasic, FileSections_ListAll
 from .ContextSymbols import SymbolSpecialType, ContextSymbol
 from .SymbolsSegment import SymbolsSegment

--- a/spimdisasm/disasmdis/DisasmdisInternals.py
+++ b/spimdisasm/disasmdis/DisasmdisInternals.py
@@ -50,6 +50,8 @@ def getWordFromStr(inputStr: str) -> int:
             temp *= 16
             temp += int(char, 16)
         arr.append(temp)
+    while len(arr) % 4 != 0:
+        arr.append(0)
     return common.Utils.bytesToWords(arr)[0]
 
 def wordGeneratorFromStrList(inputlist: list|None) -> Generator[int, None, None]:

--- a/spimdisasm/disasmdis/__init__.py
+++ b/spimdisasm/disasmdis/__init__.py
@@ -6,4 +6,4 @@
 from __future__ import annotations
 
 
-from .DisasmdisInternals import getArgsParser, applyArgs, getInstrCategoryFromStr, wordGeneratorFromStrList, disasmdisMain
+from .DisasmdisInternals import getToolDescription, addOptionsToParser, getArgsParser, applyArgs, getInstrCategoryFromStr, wordGeneratorFromStrList, processArguments, addSubparser, disasmdisMain

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -70,6 +70,8 @@ def applyGlobalConfigurations() -> None:
 
     common.GlobalConfig.ALLOW_UNKSEGMENT = False
 
+    common.GlobalConfig.INPUT_FILE_TYPE = common.InputFileType.ELF
+
 
 def applyReadelfLikeFlags(elfFile: elf32.Elf32File, args: argparse.Namespace) -> None:
     if args.all:

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -18,11 +18,10 @@ from .. import __version__
 PROGNAME = "elfObjDisasm"
 
 
-def getArgsParser() -> argparse.ArgumentParser:
-    # TODO
-    description = ""
-    parser = argparse.ArgumentParser(description=description)
+def getToolDescription() -> str:
+    return "Experimental MIPS elf disassembler"
 
+def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("binary", help="Path to input elf binary file")
     parser.add_argument("output", help="Path to output. Use '-' to print to stdout instead")
 
@@ -51,6 +50,10 @@ def getArgsParser() -> argparse.ArgumentParser:
     mips.InstructionConfig.addParametersToArgParse(parser)
 
     return parser
+
+def getArgsParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=getToolDescription(), prog=PROGNAME)
+    return addOptionsToParser(parser)
 
 def applyArgs(args: argparse.Namespace) -> None:
     if args.libultra_syms is None:
@@ -311,8 +314,7 @@ def processGlobalOffsetTable(context: common.Context, elfFile: elf32.Elf32File) 
     return
 
 
-def elfObjDisasmMain():
-    args = getArgsParser().parse_args()
+def processArguments(args: argparse.Namespace) -> int:
     applyArgs(args)
 
     applyGlobalConfigurations()
@@ -378,3 +380,18 @@ def elfObjDisasmMain():
         context.saveContextToFile(contextPath)
 
     common.Utils.printQuietless(f"{PROGNAME} {inputPath}: Done!")
+
+    return 0
+
+def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
+    parser = subparser.add_parser(PROGNAME, help=getToolDescription())
+
+    addOptionsToParser(parser)
+
+    parser.set_defaults(func=processArguments)
+
+
+def elfObjDisasmMain():
+    args = getArgsParser().parse_args()
+
+    return processArguments(args)

--- a/spimdisasm/elfObjDisasm/__init__.py
+++ b/spimdisasm/elfObjDisasm/__init__.py
@@ -6,4 +6,4 @@
 from __future__ import annotations
 
 
-from .ElfObjDisasmInternals import getArgsParser, applyArgs, applyGlobalConfigurations, getOutputPath, getProcessedSections, changeGlobalSegmentRanges, insertSymtabIntoContext, insertDynsymIntoContext, injectAllElfSymbols, processGlobalOffsetTable, elfObjDisasmMain
+from .ElfObjDisasmInternals import getToolDescription, addOptionsToParser, getArgsParser, applyArgs, applyGlobalConfigurations, getOutputPath, getProcessedSections, changeGlobalSegmentRanges, insertSymtabIntoContext, insertDynsymIntoContext, injectAllElfSymbols, processGlobalOffsetTable, processArguments, addSubparser, elfObjDisasmMain

--- a/spimdisasm/frontendCommon/FrontendUtilities.py
+++ b/spimdisasm/frontendCommon/FrontendUtilities.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 from typing import Callable
+
+import spimdisasm
 
 from .. import common
 from .. import mips
@@ -155,3 +158,17 @@ def progressCallback_migrateFunctions(i: int, funcName: str, funcTotal: int) -> 
     progressStr = f" Writing: {i/funcTotal:%}. Function: {funcName}\r"
     _sLenLastLine = max(len(progressStr), _sLenLastLine)
     common.Utils.printQuietless(progressStr, end="")
+
+
+def cliMain():
+    parser = argparse.ArgumentParser(description="Interface to call any of the spimdisasm's CLI utilities", prog="spimdisasm")
+
+    subparsers = parser.add_subparsers(description="action", help="The CLI utility to run", required=True)
+
+    spimdisasm.disasmdis.addSubparser(subparsers)
+    spimdisasm.singleFileDisasm.addSubparser(subparsers)
+    spimdisasm.elfObjDisasm.addSubparser(subparsers)
+    spimdisasm.rspDisasm.addSubparser(subparsers)
+
+    args = parser.parse_args()
+    return args.func(args)

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: © 2022 Decompollaborate
+# SPDX-FileCopyrightText: © 2022-2023 Decompollaborate
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
 
-import dataclasses
 from typing import TextIO
 from pathlib import Path
 
@@ -15,6 +14,7 @@ from .. import common
 
 from . import sections
 from . import symbols
+from . import FunctionRodataEntry
 
 
 def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_bytes: bytearray, outputPath: Path, context: common.Context) -> sections.SectionBase:
@@ -59,39 +59,9 @@ def writeSection(path: Path, fileSection: sections.SectionBase):
     return path
 
 
-@dataclasses.dataclass
-class FunctionRodataEntry:
-    function: symbols.SymbolFunction | None = None
-    rodataSyms: list[symbols.SymbolBase] = dataclasses.field(default_factory=list)
-    lateRodataSyms: list[symbols.SymbolBase] = dataclasses.field(default_factory=list)
-
-    @staticmethod
-    def getEntryFromSections(func: symbols.SymbolFunction, rodataSection: sections.SectionRodata) -> FunctionRodataEntry:
-        rodataList: list[symbols.SymbolBase] = []
-        lateRodataList: list[symbols.SymbolBase] = []
-
-        intersection = func.instrAnalyzer.referencedVrams & rodataSection.symbolsVRams
-        if len(intersection) == 0:
-            return FunctionRodataEntry(func)
-
-        for rodataSym in rodataSection.symbolList:
-            if rodataSym.vram not in intersection:
-                continue
-
-            if not rodataSym.shouldMigrate():
-                continue
-
-            if rodataSym.contextSym.isLateRodata():
-                lateRodataList.append(rodataSym)
-            else:
-                rodataList.append(rodataSym)
-
-        return FunctionRodataEntry(func, rodataList, lateRodataList)
-
-
 #! @deprecated
 def getRdataAndLateRodataForFunctionFromSection(func: symbols.SymbolFunction, rodataSection: sections.SectionRodata) -> tuple[list[symbols.SymbolBase], list[symbols.SymbolBase], int]:
-    entry = FunctionRodataEntry.getEntryFromSections(func, rodataSection)
+    entry = FunctionRodataEntry.getEntryFromSection(func, rodataSection)
 
     lateRodataSize = 0
     for rodataSym in entry.lateRodataSyms:
@@ -99,69 +69,29 @@ def getRdataAndLateRodataForFunctionFromSection(func: symbols.SymbolFunction, ro
 
     return entry.rodataSyms, entry.lateRodataSyms, lateRodataSize
 
+#! @deprecated
 def getRdataAndLateRodataForFunction(func: symbols.SymbolFunction, rodataFileList: list[sections.SectionBase]) -> tuple[list[symbols.SymbolBase], list[symbols.SymbolBase], int]:
-    rdataList: list[symbols.SymbolBase] = []
-    lateRodataList: list[symbols.SymbolBase] = []
+    entry = FunctionRodataEntry.getEntryFromPossibleRodataSections(func, rodataFileList)
+
     lateRodataSize = 0
+    for rodataSym in entry.lateRodataSyms:
+        lateRodataSize += rodataSym.sizew
 
-    for rodataSection in rodataFileList:
-        assert isinstance(rodataSection, sections.SectionRodata)
+    return entry.rodataSyms, entry.lateRodataSyms, lateRodataSize
 
-        if len(rdataList) > 0 or len(lateRodataList) > 0:
-            # We already have the rodata for this function. Stop searching
-            break
-
-        # Skip the file if there's nothing in this file refenced by the current function
-        intersection = func.instrAnalyzer.referencedVrams & rodataSection.symbolsVRams
-        if len(intersection) == 0:
-            continue
-
-        rdataList, lateRodataList, lateRodataSize = getRdataAndLateRodataForFunctionFromSection(func, rodataSection)
-
-    return rdataList, lateRodataList, lateRodataSize
-
-# Note: the `lateRodataSize` parameter is deprecated and ignored, it has been kept because of compatibility reasons
+#! @deprecated
 def writeFunctionRodataToFile(f: TextIO, func: symbols.SymbolFunction, rdataList: list[symbols.SymbolBase], lateRodataList: list[symbols.SymbolBase], lateRodataSize: int=0):
+    entry = FunctionRodataEntry(func, rdataList, lateRodataList)
+    entry.writeToFile(f, writeFunction=False)
 
-    if len(rdataList) > 0:
-        # Write the rdata
-        sectionName = ".rodata"
-        f.write(f".section {sectionName}" + common.GlobalConfig.LINE_ENDS)
-        for sym in rdataList:
-            f.write(sym.disassemble(migrate=True, useGlobalLabel=True))
-            f.write(common.GlobalConfig.LINE_ENDS)
-
-    if len(lateRodataList) > 0:
-        # Write the late_rodata
-        f.write(".section .late_rodata" + common.GlobalConfig.LINE_ENDS)
-
-        lateRodataSize = 0
-        for sym in lateRodataList:
-            lateRodataSize += sym.sizew
-
-        if lateRodataSize / len(func.instructions) > 1/3:
-            align = 4
-            firstLateRodataVram = lateRodataList[0].vram
-            if firstLateRodataVram is not None and firstLateRodataVram % 8 == 0:
-                align = 8
-            f.write(f".late_rodata_alignment {align}" + common.GlobalConfig.LINE_ENDS)
-        for sym in lateRodataList:
-            f.write(sym.disassemble(migrate=True, useGlobalLabel=True))
-            f.write(common.GlobalConfig.LINE_ENDS)
-
-    if len(rdataList) > 0 or len(lateRodataList) > 0:
-        f.write(common.GlobalConfig.LINE_ENDS + ".section .text" + common.GlobalConfig.LINE_ENDS)
-
+#! @deprecated
 def writeSplitedFunction(path: Path, func: symbols.SymbolFunction, rodataFileList: list[sections.SectionBase]):
     path.mkdir(parents=True, exist_ok=True)
+    entry = FunctionRodataEntry.getEntryFromPossibleRodataSections(func, rodataFileList)
 
     funcPath = path / (func.getName()+ ".s")
     with funcPath.open("w") as f:
-        rdataList, lateRodataList, lateRodataSize = getRdataAndLateRodataForFunction(func, rodataFileList)
-        writeFunctionRodataToFile(f, func, rdataList, lateRodataList, lateRodataSize)
-
-        # Write the function itself
-        f.write(func.disassemble(migrate=True))
+        entry.writeToFile(f, writeFunction=True)
 
 def writeOtherRodata(path: Path, rodataFileList: list[sections.SectionBase]):
     for rodataSection in rodataFileList:
@@ -178,43 +108,6 @@ def writeOtherRodata(path: Path, rodataFileList: list[sections.SectionBase]):
             with rodataSymbolPath.open("w") as f:
                 f.write(".section .rodata" + common.GlobalConfig.LINE_ENDS)
                 f.write(rodataSym.disassemble(migrate=True))
-
-
-def getFunctionsAndRodataSymsFromSections(textSection: sections.SectionText, rodataSection: sections.SectionRodata) -> list[FunctionRodataEntry]:
-    allUnmigratedRodataSymbols: list[symbols.SymbolBase] = []
-
-    for rodataSym in rodataSection.symbolList:
-        if not rodataSym.shouldMigrate():
-            # We only care for the symbols which will not be migrated
-            allUnmigratedRodataSymbols.append(rodataSym)
-
-    allEntries: list[FunctionRodataEntry] = []
-
-    for func in textSection.symbolList:
-        assert isinstance(func, symbols.SymbolFunction)
-
-        entry = FunctionRodataEntry.getEntryFromSections(func, rodataSection)
-
-        if len(entry.rodataSyms) > 0:
-            firstFuncRodataSym = entry.rodataSyms[0]
-
-            while len(allUnmigratedRodataSymbols) > 0:
-                rodataSym = allUnmigratedRodataSymbols[0]
-
-                if rodataSym.vram >= firstFuncRodataSym.vram:
-                    # Take all the symbols up to the first rodata sym referenced by the current function
-                    break
-
-                allEntries.append(FunctionRodataEntry(rodataSyms=[rodataSym]))
-                del allUnmigratedRodataSymbols[0]
-
-        allEntries.append(entry)
-
-    # Check if there's any rodata symbol remaining and add it to the list
-    for rodataSym in allUnmigratedRodataSymbols:
-        allEntries.append(FunctionRodataEntry(rodataSyms=[rodataSym]))
-
-    return allEntries
 
 
 def writeMigratedFunctionsList(processedSegments: dict[common.FileSectionType, list[sections.SectionBase]], functionMigrationPath: Path, name: str) -> None:

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -64,6 +64,9 @@ def getRdataAndLateRodataForFunctionFromSection(func: symbols.SymbolFunction, ro
     lateRodataSize = 0
 
     intersection = func.instrAnalyzer.referencedVrams & rodataSection.symbolsVRams
+    if len(intersection) == 0:
+        return [], [], 0
+
     for rodataSym in rodataSection.symbolList:
         if rodataSym.vram not in intersection:
             continue
@@ -100,7 +103,9 @@ def getRdataAndLateRodataForFunction(func: symbols.SymbolFunction, rodataFileLis
 
     return rdataList, lateRodataList, lateRodataSize
 
-def writeFunctionRodataToFile(f: TextIO, func: symbols.SymbolFunction, rdataList: list[symbols.SymbolBase], lateRodataList: list[symbols.SymbolBase], lateRodataSize: int):
+# Note: the `lateRodataSize` parameter is deprecated and ignored, it has been kept because of compatibility reasons
+def writeFunctionRodataToFile(f: TextIO, func: symbols.SymbolFunction, rdataList: list[symbols.SymbolBase], lateRodataList: list[symbols.SymbolBase], lateRodataSize: int=0):
+
     if len(rdataList) > 0:
         # Write the rdata
         sectionName = ".rodata"
@@ -112,6 +117,11 @@ def writeFunctionRodataToFile(f: TextIO, func: symbols.SymbolFunction, rdataList
     if len(lateRodataList) > 0:
         # Write the late_rodata
         f.write(".section .late_rodata" + common.GlobalConfig.LINE_ENDS)
+
+        lateRodataSize = 0
+        for sym in lateRodataList:
+            lateRodataSize += sym.sizew
+
         if lateRodataSize / len(func.instructions) > 1/3:
             align = 4
             firstLateRodataVram = lateRodataList[0].vram

--- a/spimdisasm/mips/FuncRodataEntry.py
+++ b/spimdisasm/mips/FuncRodataEntry.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2023 Decompollaborate
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TextIO
+
+import dataclasses
+
+from .. import common
+
+from . import sections
+from . import symbols
+
+
+@dataclasses.dataclass
+class FunctionRodataEntry:
+    function: symbols.SymbolFunction | None = None
+    rodataSyms: list[symbols.SymbolBase] = dataclasses.field(default_factory=list)
+    lateRodataSyms: list[symbols.SymbolBase] = dataclasses.field(default_factory=list)
+
+    def hasRodataSyms(self) -> bool:
+        return len(self.rodataSyms) > 0 or len(self.lateRodataSyms) > 0
+
+    def writeToFile(self, f: TextIO, writeFunction: bool=True):
+        if len(self.rodataSyms) > 0:
+            # Write the rdata
+            f.write(f".section .rodata{common.GlobalConfig.LINE_ENDS}")
+            for sym in self.rodataSyms:
+                f.write(sym.disassemble(migrate=True, useGlobalLabel=True))
+                f.write(common.GlobalConfig.LINE_ENDS)
+
+        if len(self.lateRodataSyms) > 0:
+            assert self.function is not None
+            # Write the late_rodata
+            f.write(f".section .late_rodata{common.GlobalConfig.LINE_ENDS}")
+
+            lateRodataSize = 0
+            for sym in self.lateRodataSyms:
+                lateRodataSize += sym.sizew
+
+            if lateRodataSize / len(self.function.instructions) > 1/3:
+                align = 4
+                firstLateRodataVram = self.lateRodataSyms[0].vram
+                if firstLateRodataVram is not None and firstLateRodataVram % 8 == 0:
+                    align = 8
+                f.write(f".late_rodata_alignment {align}{common.GlobalConfig.LINE_ENDS}")
+            for sym in self.lateRodataSyms:
+                f.write(sym.disassemble(migrate=True, useGlobalLabel=True))
+                f.write(common.GlobalConfig.LINE_ENDS)
+
+        if len(self.rodataSyms) > 0 or len(self.lateRodataSyms) > 0:
+            f.write(f"{common.GlobalConfig.LINE_ENDS}.section .text{common.GlobalConfig.LINE_ENDS}")
+
+        if writeFunction and self.function is not None:
+            # Write the function itself
+            f.write(self.function.disassemble(migrate=True))
+
+    @staticmethod
+    def getEntryFromSection(func: symbols.SymbolFunction, rodataSection: sections.SectionRodata) -> FunctionRodataEntry:
+        rodataList: list[symbols.SymbolBase] = []
+        lateRodataList: list[symbols.SymbolBase] = []
+
+        intersection = func.instrAnalyzer.referencedVrams & rodataSection.symbolsVRams
+        if len(intersection) == 0:
+            return FunctionRodataEntry(func)
+
+        for rodataSym in rodataSection.symbolList:
+            if rodataSym.vram not in intersection:
+                continue
+
+            if not rodataSym.shouldMigrate():
+                continue
+
+            if rodataSym.contextSym.isLateRodata():
+                lateRodataList.append(rodataSym)
+            else:
+                rodataList.append(rodataSym)
+
+        return FunctionRodataEntry(func, rodataList, lateRodataList)
+
+    @staticmethod
+    def getEntryFromPossibleRodataSections(func: symbols.SymbolFunction, rodataFileList: list[sections.SectionBase]) -> FunctionRodataEntry:
+        for rodataSection in rodataFileList:
+            assert isinstance(rodataSection, sections.SectionRodata)
+
+            # Skip the file if there's nothing in this file refenced by the current function
+            intersection = func.instrAnalyzer.referencedVrams & rodataSection.symbolsVRams
+            if len(intersection) == 0:
+                continue
+
+            entry = FunctionRodataEntry.getEntryFromSection(func, rodataSection)
+            if entry.hasRodataSyms():
+                return entry
+
+        return FunctionRodataEntry(func)
+
+    @staticmethod
+    def getAllEntriesFromSections(textSection: sections.SectionText, rodataSection: sections.SectionRodata) -> list[FunctionRodataEntry]:
+        allUnmigratedRodataSymbols: list[symbols.SymbolBase] = []
+
+        for rodataSym in rodataSection.symbolList:
+            if not rodataSym.shouldMigrate():
+                # We only care for the symbols which will not be migrated
+                allUnmigratedRodataSymbols.append(rodataSym)
+
+        allEntries: list[FunctionRodataEntry] = []
+
+        for func in textSection.symbolList:
+            assert isinstance(func, symbols.SymbolFunction)
+
+            entry = FunctionRodataEntry.getEntryFromSection(func, rodataSection)
+
+            if len(entry.rodataSyms) > 0:
+                firstFuncRodataSym = entry.rodataSyms[0]
+
+                while len(allUnmigratedRodataSymbols) > 0:
+                    rodataSym = allUnmigratedRodataSymbols[0]
+
+                    if rodataSym.vram >= firstFuncRodataSym.vram:
+                        # Take all the symbols up to the first rodata sym referenced by the current function
+                        break
+
+                    allEntries.append(FunctionRodataEntry(rodataSyms=[rodataSym]))
+                    del allUnmigratedRodataSymbols[0]
+
+            allEntries.append(entry)
+
+        # Check if there's any rodata symbol remaining and add it to the list
+        for rodataSym in allUnmigratedRodataSymbols:
+            allEntries.append(FunctionRodataEntry(rodataSyms=[rodataSym]))
+
+        return allEntries

--- a/spimdisasm/mips/__init__.py
+++ b/spimdisasm/mips/__init__.py
@@ -13,3 +13,5 @@ from . import FilesHandlers
 from .InstructionConfig import InstructionConfig
 from .MipsFileBase import FileBase, createEmptyFile
 from .MipsFileSplits import FileSplits
+
+from .FuncRodataEntry import FunctionRodataEntry

--- a/spimdisasm/mips/__init__.py
+++ b/spimdisasm/mips/__init__.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from . import sections
 from . import symbols
 
+from .FuncRodataEntry import FunctionRodataEntry
+
 from . import FilesHandlers
 
 from .InstructionConfig import InstructionConfig
 from .MipsFileBase import FileBase, createEmptyFile
 from .MipsFileSplits import FileSplits
-
-from .FuncRodataEntry import FunctionRodataEntry

--- a/spimdisasm/mips/sections/MipsSectionBase.py
+++ b/spimdisasm/mips/sections/MipsSectionBase.py
@@ -11,7 +11,7 @@ from ..MipsFileBase import FileBase
 
 class SectionBase(FileBase):
     def checkWordIsASymbolReference(self, word: int) -> bool:
-        if word < self.context.totalVramStart or word >= self.context.totalVramEnd:
+        if not self.context.totalVramRange.isInRange(word):
             return False
         if self.context.isAddressBanned(word):
             return False

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -201,6 +201,12 @@ class SymbolBase(common.ElementBase):
                         referencedSym.referenceSymbols.add(self.contextSym)
 
 
+    def getEndOfLineComment(self, wordIndex: int) -> str:
+        if not common.GlobalConfig.ASM_COMMENT:
+            return ""
+
+        return self.endOfLineComment.get(wordIndex, "")
+
     def getJByteAsByte(self, i: int, j: int) -> str:
         localOffset = 4*i
         w = self.words[i]
@@ -299,9 +305,7 @@ class SymbolBase(common.ElementBase):
 
         comment = self.generateAsmLineComment(localOffset)
         output += f"{label}{comment} {dotType} {value}"
-        endComment = self.endOfLineComment.get(i)
-        if endComment is not None:
-            output += endComment
+        output += self.getEndOfLineComment(i)
         output += common.GlobalConfig.LINE_ENDS
 
         return output, 0
@@ -322,9 +326,7 @@ class SymbolBase(common.ElementBase):
 
         comment = self.generateAsmLineComment(localOffset, w)
         output += f"{label}{comment} {dotType} {value}"
-        endComment = self.endOfLineComment.get(i)
-        if endComment is not None:
-            output += endComment
+        output += self.getEndOfLineComment(i)
         output += common.GlobalConfig.LINE_ENDS
 
         return output, 0
@@ -347,9 +349,7 @@ class SymbolBase(common.ElementBase):
 
         comment = self.generateAsmLineComment(localOffset, doubleWord)
         output += f"{label}{comment} {dotType} {value}"
-        endComment = self.endOfLineComment.get(i)
-        if endComment is not None:
-            output += endComment
+        output += self.getEndOfLineComment(i)
         output += common.GlobalConfig.LINE_ENDS
 
         return output, 1

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -17,7 +17,7 @@ class SymbolFunction(SymbolText):
         super().__init__(context, vromStart, vromEnd, inFileOffset, vram, list(), segmentVromStart, overlayCategory)
         self.instructions = list(instrsList)
 
-        self.instrAnalyzer = analysis.InstrAnalyzer(self.vram)
+        self.instrAnalyzer = analysis.InstrAnalyzer(self.vram, context)
 
         self.branchesTaken: set[int] = set()
 
@@ -85,8 +85,9 @@ class SymbolFunction(SymbolText):
 
             self.instrAnalyzer.printAnalisisDebugInfo_IterInfo(regsTracker, instr, currentVram)
 
-            if not self.isLikelyHandwritten:
-                self.isLikelyHandwritten = instr.isLikelyHandwritten()
+            if instr.isLikelyHandwritten():
+                self.isLikelyHandwritten = True
+                self.endOfLineComment[instructionOffset//4] = " # handwritten instruction"
 
             if not common.GlobalConfig.DISASSEMBLE_UNKNOWN_INSTRUCTIONS and not instr.isImplemented():
                 # Abort analysis
@@ -330,8 +331,10 @@ class SymbolFunction(SymbolText):
             funcSym.referenceFunctions.add(self.contextSym)
 
 
-        if not self.isRsp and len(self.instrAnalyzer.funcCallOutsideRangesOffsets) > 0:
-            self.isLikelyHandwritten = True
+        if not self.isRsp:
+            for outsideInstrOffset in self.instrAnalyzer.funcCallOutsideRangesOffsets.keys():
+                self.isLikelyHandwritten = True
+                self.endOfLineComment[outsideInstrOffset//4] = " # function call outside to known address range"
 
         # Symbols
         for loOffset, symVram in self.instrAnalyzer.symbolLoInstrOffset.items():
@@ -581,7 +584,7 @@ class SymbolFunction(SymbolText):
 
         line = instr.disassemble(immOverride, extraLJust=extraLJust)
 
-        return f"{comment}  {line}{common.GlobalConfig.LINE_ENDS}"
+        return f"{comment}  {line}"
 
 
     def _emitCpload(self, instr: rabbitizer.Instruction, instructionOffset: int, wasLastInstABranch: bool) -> str:
@@ -596,7 +599,7 @@ class SymbolFunction(SymbolText):
             output += f"# _gp_disp: 0x{gpDisp:X}{common.GlobalConfig.LINE_ENDS}"
             if common.GlobalConfig.EMIT_CPLOAD:
                 assert cpload.reg is not None
-                output += f".cpload ${cpload.reg.name}" + common.GlobalConfig.LINE_ENDS
+                output += f".cpload ${cpload.reg.name}"
             else:
                 output += self._emitInstruction(instr, instructionOffset, wasLastInstABranch)
         else:
@@ -636,6 +639,8 @@ class SymbolFunction(SymbolText):
             else:
                 output += self._emitInstruction(instr, instructionOffset, wasLastInstABranch)
 
+            output += f"{self.getEndOfLineComment(instructionOffset//4)}{common.GlobalConfig.LINE_ENDS}"
+
             wasLastInstABranch = instr.hasDelaySlot()
             instructionOffset += 4
 
@@ -651,8 +656,7 @@ class SymbolFunction(SymbolText):
     def disassembleAsData(self, useGlobalLabel: bool=True) -> str:
         self.words = []
         for i, instr in enumerate(self.instructions):
-            if common.GlobalConfig.ASM_COMMENT:
-                if not instr.isImplemented() or not instr.isValid():
-                    self.endOfLineComment[i] = " # invalid instruction"
+            if not instr.isImplemented() or not instr.isValid():
+                self.endOfLineComment[i] = " # invalid instruction"
             self.words.append(instr.getRaw())
         return super().disassembleAsData(useGlobalLabel=useGlobalLabel)

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -331,10 +331,10 @@ class SymbolFunction(SymbolText):
             funcSym.referenceFunctions.add(self.contextSym)
 
 
-        if not self.isRsp:
-            for outsideInstrOffset in self.instrAnalyzer.funcCallOutsideRangesOffsets.keys():
-                self.isLikelyHandwritten = True
-                self.endOfLineComment[outsideInstrOffset//4] = " # function call outside to known address range"
+        # if not self.isRsp and common.GlobalConfig.INPUT_FILE_TYPE != common.InputFileType.ELF:
+        #     for outsideInstrOffset in self.instrAnalyzer.funcCallOutsideRangesOffsets.keys():
+        #         self.isLikelyHandwritten = True
+        #         self.endOfLineComment[outsideInstrOffset//4] = " # function call outside to the known address range"
 
         # Symbols
         for loOffset, symVram in self.instrAnalyzer.symbolLoInstrOffset.items():

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -36,8 +36,10 @@ class CploadInfo:
 
 
 class InstrAnalyzer:
-    def __init__(self, funcVram: int) -> None:
+    def __init__(self, funcVram: int, context: common.Context) -> None:
         self.funcVram = funcVram
+        self.context = context
+        "read-only"
 
         self.referencedVrams: set[int] = set()
         "Every referenced vram found"
@@ -59,7 +61,7 @@ class InstrAnalyzer:
         self.funcCallInstrOffsets: dict[int, int] = dict()
         "key: func call instruction offset, value: target vram"
         self.funcCallOutsideRangesOffsets: dict[int, int] = dict()
-        "key: func call instruction offset, value: target vram which is outside the [0x80000000, 0x84000000] range"
+        "key: func call instruction offset, value: target vram which is outside the known vram address range"
 
         # Jump register (jumptables)
         self.jumpRegisterIntrOffset: dict[int, int] = dict()
@@ -133,7 +135,7 @@ class InstrAnalyzer:
             return
 
         target = instr.getInstrIndexAsVram()
-        if target >= 0x84000000 or target < 0x80000000:
+        if not self.context.isAddressInGlobalRange(target):
             self.funcCallOutsideRangesOffsets[instrOffset] = target
 
         if not common.GlobalConfig.PIC:

--- a/spimdisasm/rspDisasm/RspDisasmInternals.py
+++ b/spimdisasm/rspDisasm/RspDisasmInternals.py
@@ -13,11 +13,10 @@ from .. import common
 from .. import mips
 
 
-def getArgsParser() -> argparse.ArgumentParser:
-    description = "RSP N64 disassembler"
-    parser = argparse.ArgumentParser(description=description)
+def getToolDescription() -> str:
+    return "N64 RSP disassembler"
 
-
+def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("binary", help="Path to input binary")
     parser.add_argument("output", help="Path to output. Use '-' to print to stdout instead")
 
@@ -32,6 +31,11 @@ def getArgsParser() -> argparse.ArgumentParser:
     mips.InstructionConfig.addParametersToArgParse(parser)
 
     return parser
+
+def getArgsParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=getToolDescription())
+    return addOptionsToParser(parser)
+
 
 def applyArgs(args: argparse.Namespace) -> None:
     mips.InstructionConfig.parseArgs(args)
@@ -59,8 +63,7 @@ def initializeContext(args: argparse.Namespace, fileSize: int, fileVram: int) ->
     return context
 
 
-def rspDisasmMain():
-    args = getArgsParser().parse_args()
+def processArguments(args: argparse.Namespace) -> int:
     applyArgs(args)
 
     applyGlobalConfigurations()
@@ -89,3 +92,18 @@ def rspDisasmMain():
         contextPath = Path(args.save_context)
         contextPath.parent.mkdir(parents=True, exist_ok=True)
         context.saveContextToFile(contextPath)
+
+    return 0
+
+def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
+    parser = subparser.add_parser("rspDisasm", help=getToolDescription())
+
+    addOptionsToParser(parser)
+
+    parser.set_defaults(func=processArguments)
+
+
+def rspDisasmMain():
+    args = getArgsParser().parse_args()
+
+    return processArguments(args)

--- a/spimdisasm/rspDisasm/__init__.py
+++ b/spimdisasm/rspDisasm/__init__.py
@@ -6,4 +6,4 @@
 from __future__ import annotations
 
 
-from .RspDisasmInternals import getArgsParser, applyArgs, initializeContext, rspDisasmMain
+from .RspDisasmInternals import getToolDescription, addOptionsToParser, getArgsParser, applyArgs, initializeContext, processArguments, addSubparser, rspDisasmMain

--- a/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
+++ b/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
@@ -13,10 +13,10 @@ from .. import mips
 from .. import frontendCommon as fec
 
 
-def getArgsParser() -> argparse.ArgumentParser:
-    description = "General purpose N64-mips disassembler"
-    parser = argparse.ArgumentParser(description=description)
+def getToolDescription() -> str:
+    return "General purpose N64-mips disassembler"
 
+def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("binary", help="Path to input binary")
     parser.add_argument("output", help="Path to output. Use '-' to print to stdout instead")
 
@@ -49,6 +49,10 @@ def getArgsParser() -> argparse.ArgumentParser:
     mips.InstructionConfig.addParametersToArgParse(parser)
 
     return parser
+
+def getArgsParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=getToolDescription())
+    return addOptionsToParser(parser)
 
 def applyArgs(args: argparse.Namespace) -> None:
     mips.InstructionConfig.parseArgs(args)
@@ -119,8 +123,7 @@ def changeGlobalSegmentRanges(context: common.Context, processedFiles: dict[comm
     return
 
 
-def disassemblerMain():
-    args = getArgsParser().parse_args()
+def processArguments(args: argparse.Namespace) -> int:
     applyArgs(args)
 
     applyGlobalConfigurations()
@@ -185,3 +188,18 @@ def disassemblerMain():
     common.Utils.printVerbose()
     common.Utils.printVerbose("Disassembling complete!")
     common.Utils.printVerbose("Goodbye.")
+
+    return 0
+
+def addSubparser(subparser: argparse._SubParsersAction[argparse.ArgumentParser]):
+    parser = subparser.add_parser("singleFileDisasm", help=getToolDescription())
+
+    addOptionsToParser(parser)
+
+    parser.set_defaults(func=processArguments)
+
+
+def disassemblerMain():
+    args = getArgsParser().parse_args()
+
+    return processArguments(args)

--- a/spimdisasm/singleFileDisasm/__init__.py
+++ b/spimdisasm/singleFileDisasm/__init__.py
@@ -6,4 +6,4 @@
 from __future__ import annotations
 
 
-from .SingleFileDisasmInternals import getArgsParser, applyArgs, applyGlobalConfigurations, getSplits, changeGlobalSegmentRanges, disassemblerMain
+from .SingleFileDisasmInternals import getToolDescription, addOptionsToParser, getArgsParser, applyArgs, applyGlobalConfigurations, getSplits, changeGlobalSegmentRanges, processArguments, addSubparser, disassemblerMain


### PR DESCRIPTION
- CLI changes:
  - Install CLI tools as actual terminal programs
  - Allow invoking the CLI tools from spimdisasm as subparsers
  - The old way of invoking the CLI tools (`python3 -m spimdisasm.clitool`) is now deprecated, but still works
- `disasmdis`: Fix crash if the input isn't a multiple of a word
- Report with a comment which instruction made spimdisasm detected as a handwritten instruction
- New in the API: `FunctionRodataEntry`
  - Cleaner interface for rodata migration and similar functions
  - Provides method for intermixing functions and non-migrated rodata symbols in a way the correct order is still preserved
  - Old functions from `FileHandlers` which provided rodata migration functionalities are now deprecated