### PR TITLE
1.12.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.12.5.dev0"
+version = "1.12.5"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.12.4"
+version = "1.12.5.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 12, 5)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 12, 4)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 12, 5)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -279,6 +279,7 @@ class GlobalConfig:
         miscConfig.add_argument("--asm-end-label", help=f"Tells the disassembler to start using an end label for functions")
         miscConfig.add_argument("--asm-func-as-label", help=f"Toggle adding the function name as an additional label. Defaults to {GlobalConfig.ASM_TEXT_FUNC_AS_LABEL}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--asm-data-as-label", help=f"Toggle adding the data symbol name as an additional label. Defaults to {GlobalConfig.ASM_DATA_SYM_AS_LABEL}", action=Utils.BooleanOptionalAction)
+        miscConfig.add_argument("--asm-emit-size-directive", help=f"Toggles emitting a size directive to generated symbols. Defaults to {GlobalConfig.ASM_EMIT_SIZE_DIRECTIVE}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--asm-use-prelude", help=f"Toggle use of the default prelude for asm files. Defaults to {GlobalConfig.ASM_USE_PRELUDE}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--asm-generated-by", help=f"Toggle comment indicating the tool and version used to generate the disassembly. Defaults to {GlobalConfig.ASM_GENERATED_BY}", action=Utils.BooleanOptionalAction)
 
@@ -428,6 +429,8 @@ class GlobalConfig:
             GlobalConfig.ASM_TEXT_FUNC_AS_LABEL = args.asm_func_as_label
         if args.asm_data_as_label is not None:
             GlobalConfig.ASM_DATA_SYM_AS_LABEL = args.asm_data_as_label
+        if args.asm_emit_size_directive is not None:
+            GlobalConfig.ASM_EMIT_SIZE_DIRECTIVE = args.asm_emit_size_directive
         if args.asm_use_prelude is not None:
             GlobalConfig.ASM_USE_PRELUDE = args.asm_use_prelude
         if args.asm_generated_by is not None:

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -189,6 +189,7 @@ class GlobalConfig:
     ASM_TEXT_END_LABEL: str = ""
     ASM_TEXT_FUNC_AS_LABEL: bool = False
     ASM_DATA_SYM_AS_LABEL: bool = False
+    ASM_EMIT_SIZE_DIRECTIVE: bool = False
     ASM_USE_PRELUDE: bool = True
     ASM_GENERATED_BY: bool = True
 

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -408,7 +408,7 @@ class Elf32File:
                 symName = ""
                 if self.strtab is not None:
                     symName = self.strtab[sym.name]
-                print(f" {i:>5}: {sym.value:08X} {sym.size:>5} {entryType.name:7} {bind:6} {visibility:7} {ndx:>7} {symName}")
+                print(f" {i:>5}: {sym.value:08X} {sym.size:>5X} {entryType.name:7} {bind:6} {visibility:7} {ndx:>7} {symName}")
 
     def readelf_relocs(self) -> None:
         for relSection in self.rel.values():

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -35,6 +35,8 @@ def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r5900"])
 
+    parser.add_argument("--function-info", help="Specifies a path where to output a csvs sumary file of every analyzed function", metavar="PATH")
+
 
     readelfOptions = parser.add_argument_group("readelf-like flags")
 
@@ -390,6 +392,9 @@ def processArguments(args: argparse.Namespace) -> int:
         contextPath = Path(args.save_context)
         contextPath.parent.mkdir(parents=True, exist_ok=True)
         context.saveContextToFile(contextPath)
+
+    if args.function_info is not None:
+        fec.FrontendUtilities.writeFunctionInfoCsv(processedSegments, Path(args.function_info))
 
     common.Utils.printQuietless(f"{PROGNAME} {inputPath}: Done!")
 

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -73,6 +73,8 @@ class SectionRodata(SectionBase):
         lastVramSymbol: common.ContextSymbol | None = None
 
         partOfJumpTable = False
+        firstJumptableWord = -1
+
         for w in self.words:
             currentVram = self.getVramOffset(localOffset)
             contextSym = self.getSymbol(currentVram, tryPlusOffset=False)
@@ -83,6 +85,7 @@ class SectionRodata(SectionBase):
 
             if contextSym is not None and contextSym.isJumpTable():
                 partOfJumpTable = True
+                firstJumptableWord = w
 
             elif partOfJumpTable:
                 # The last symbol found was part of a jumptable, check if this word still is part of the jumptable
@@ -96,7 +99,7 @@ class SectionRodata(SectionBase):
                 elif contextSym is not None:
                     partOfJumpTable = False
 
-                elif ((w >> 24) & 0xFF) != 0x80:
+                elif ((w >> 24) & 0xFF) != ((firstJumptableWord >> 24) & 0xFF):
                     partOfJumpTable = False
                     if lastVramSymbol is not None and lastVramSymbol.isJumpTable() and lastVramSymbol.isGot and common.GlobalConfig.GP_VALUE is not None:
                         partOfJumpTable = True

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -465,7 +465,8 @@ class SymbolBase(common.ElementBase):
         output = self.contextSym.getReferenceeSymbols()
         output += self.getPrevAlignDirective(0)
 
-        output += self.getSymbolAsmDeclaration(self.getName(), useGlobalLabel)
+        symName = self.getName()
+        output += self.getSymbolAsmDeclaration(symName, useGlobalLabel)
 
         canReferenceSymbolsWithAddends = self.canUseAddendsOnData()
         canReferenceConstants = self.canUseConstantsOnData()
@@ -505,6 +506,9 @@ class SymbolBase(common.ElementBase):
 
             i += skip
             i += 1
+
+        if common.GlobalConfig.ASM_EMIT_SIZE_DIRECTIVE:
+            output += f".size {symName}, . - {symName}{common.GlobalConfig.LINE_ENDS}"
 
         nameEnd = self.getNameEnd()
         if nameEnd is not None:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -85,7 +85,7 @@ class SymbolFunction(SymbolText):
 
             self.instrAnalyzer.printAnalisisDebugInfo_IterInfo(regsTracker, instr, currentVram)
 
-            if instr.isLikelyHandwritten():
+            if instr.isLikelyHandwritten() and not self.isRsp:
                 self.isLikelyHandwritten = True
                 self.endOfLineComment[instructionOffset//4] = " # handwritten instruction"
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -706,7 +706,8 @@ class SymbolFunction(SymbolText):
                 # RSP functions are always handwritten, so this is redundant
                 output += "# Handwritten function" + common.GlobalConfig.LINE_ENDS
 
-        output += self.getSymbolAsmDeclaration(self.getName(), useGlobalLabel)
+        symName = self.getName()
+        output += self.getSymbolAsmDeclaration(symName, useGlobalLabel)
 
         wasLastInstABranch = False
         instructionOffset = 0
@@ -728,6 +729,9 @@ class SymbolFunction(SymbolText):
 
             wasLastInstABranch = instr.hasDelaySlot()
             instructionOffset += 4
+
+        if common.GlobalConfig.ASM_EMIT_SIZE_DIRECTIVE:
+            output += f".size {symName}, . - {symName}{common.GlobalConfig.LINE_ENDS}"
 
         if common.GlobalConfig.ASM_TEXT_END_LABEL:
             output += f"{common.GlobalConfig.ASM_TEXT_END_LABEL} {self.getName()}" + common.GlobalConfig.LINE_ENDS


### PR DESCRIPTION
- Fix jumptable end detection algorithm on vram ranges different than `0x80XXXXXX`
- Add `--function-info` flag to `elfObjDisasm`
- Option for emitting size directives in the generated assembly
- Add `--asm-emit-size-directive` flag to emit size directives on generated assembly