### PR TITLE
1.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.14.0"
+version = "1.14.1.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.14.1.dev0"
+version = "1.14.1"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 14, 0)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 14, 1)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 14, 1)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -50,7 +50,7 @@ class FileBase(common.ElementBase):
         output += common.GlobalConfig.LINE_ENDS
         output += f".section {self.sectionType.toSectionName()}" + common.GlobalConfig.LINE_ENDS
         output += common.GlobalConfig.LINE_ENDS
-        output += ".balign 16" + common.GlobalConfig.LINE_ENDS
+        output += ".align 4" + common.GlobalConfig.LINE_ENDS
 
         return output
 

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -438,9 +438,11 @@ class SymbolBase(common.ElementBase):
                 return f".align 3{common.GlobalConfig.LINE_ENDS}"
         elif self.isJumpTable():
             if i == 0 and common.GlobalConfig.COMPILER not in {common.Compiler.IDO, common.Compiler.PSYQ}:
-
                 if self.vram % 0x8 == 0:
                     return f".align 3{common.GlobalConfig.LINE_ENDS}"
+        elif self.isString():
+            if self.vram % 0x4 == 0:
+                return f".align 2{common.GlobalConfig.LINE_ENDS}"
 
         return ""
 

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -447,21 +447,10 @@ class SymbolBase(common.ElementBase):
         return ""
 
     def getPostAlignDirective(self, i: int=0) -> str:
-        commentPaddingNum = 22
-        if not common.GlobalConfig.ASM_COMMENT:
-            commentPaddingNum = 1
-
-        alignDirective = ""
-
         if self.isString():
-            alignDirective += commentPaddingNum * " "
-            if common.GlobalConfig.COMPILER in {common.Compiler.SN64, common.Compiler.PSYQ}:
-                alignDirective += ".align 2"
-            else:
-                alignDirective += ".balign 4"
-            alignDirective += common.GlobalConfig.LINE_ENDS
+            return f".align 2{common.GlobalConfig.LINE_ENDS}"
 
-        return alignDirective
+        return ""
 
     def disassembleAsData(self, useGlobalLabel: bool=True) -> str:
         output = self.contextSym.getReferenceeSymbols()


### PR DESCRIPTION
- Emit a previous alignment directive for strings.
  - Ensures strings are always word aligned
- Purge `.balign` directive in favor of `.align` directive
- Add `py.typed` file. Whoops