### PR TITLE
1.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.14.1"
+version = "1.14.2.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"
@@ -35,6 +35,9 @@ exclude = ["build*"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
+
+[tool.setuptools.package-data]
+spimdisasm = ["py.typed"]
 
 [tool.cibuildwheel]
 skip = ["cp36-*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.14.2.dev0"
+version = "1.14.2"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 14, 1)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__ = (1, 14, 2)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__ = (1, 14, 2)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common

--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -42,19 +42,19 @@ def eprintVerbose(*args, **kwargs):
 def isStdoutRedirected() -> bool:
     return not sys.stdout.isatty()
 
-# Returns the md5 hash of a bytearray
-def getStrHash(byte_array: bytearray) -> str:
+# Returns the md5 hash of a bytes
+def getStrHash(byte_array: bytes) -> str:
     return str(hashlib.md5(byte_array).hexdigest())
 
-def writeBytearrayToFile(filepath: Path, array_of_bytes: bytearray):
+def writeBytearrayToFile(filepath: Path, array_of_bytes: bytes):
     with filepath.open(mode="wb") as f:
         f.write(array_of_bytes)
 
-def readFileAsBytearray(filepath: Path) -> bytearray:
+def readFileAsBytearray(filepath: Path) -> bytes:
     if not filepath.exists():
-        return bytearray(0)
+        return bytes(0)
     with filepath.open(mode="rb") as f:
-        return bytearray(f.read())
+        return bytes(f.read())
 
 def readFile(filepath: Path) -> list[str]:
     with filepath.open() as f:
@@ -67,7 +67,7 @@ def readJson(filepath: Path):
 def removeExtraWhitespace(line: str) -> str:
     return " ".join(line.split())
 
-def endianessBytesToWords(endian: InputEndian, array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=None) -> list[int]:
+def endianessBytesToWords(endian: InputEndian, array_of_bytes: bytes, offset: int=0, offsetEnd: int|None=None) -> list[int]:
     totalBytesCount = len(array_of_bytes)
     if totalBytesCount == 0:
         return list()
@@ -88,7 +88,9 @@ def endianessBytesToWords(endian: InputEndian, array_of_bytes: bytearray, offset
         little_byte_format = f"<{halfwords}H"
         big_byte_format = f">{halfwords}H"
         tmp = struct.unpack_from(little_byte_format, array_of_bytes, offset)
-        struct.pack_into(big_byte_format, array_of_bytes, offset, *tmp)
+        newBytes = bytearray(array_of_bytes)
+        struct.pack_into(big_byte_format, newBytes, offset, *tmp)
+        array_of_bytes = bytes(newBytes)
 
     words = bytesCount//4
     endian_format = f">{words}I"
@@ -96,13 +98,13 @@ def endianessBytesToWords(endian: InputEndian, array_of_bytes: bytearray, offset
         endian_format = f"<{words}I"
     return list(struct.unpack_from(endian_format, array_of_bytes, offset))
 
-def bytesToWords(array_of_bytes: bytearray, offset: int=0, offsetEnd: int|None=None) -> list[int]:
+def bytesToWords(array_of_bytes: bytes, offset: int=0, offsetEnd: int|None=None) -> list[int]:
     return endianessBytesToWords(GlobalConfig.ENDIAN, array_of_bytes, offset, offsetEnd)
 
 #! deprecated
 bytesToBEWords = bytesToWords
 
-def endianessWordsToBytes(endian: InputEndian, words_list: list[int], buffer: bytearray) -> bytearray:
+def endianessWordsToBytes(endian: InputEndian, words_list: list[int]) -> bytes:
     if endian == InputEndian.MIDDLE:
         raise BufferError("TODO: wordsToBytesEndianess: GlobalConfig.ENDIAN == InputEndian.MIDDLE")
 
@@ -110,11 +112,10 @@ def endianessWordsToBytes(endian: InputEndian, words_list: list[int], buffer: by
     endian_format = f">{words}I"
     if endian == InputEndian.LITTLE:
         endian_format = f"<{words}I"
-    struct.pack_into(endian_format, buffer, 0, *words_list)
-    return buffer
+    return struct.pack(endian_format, *words_list)
 
-def wordsToBytes(words_list: list[int], buffer: bytearray) -> bytearray:
-    return endianessWordsToBytes(GlobalConfig.ENDIAN, words_list, buffer)
+def wordsToBytes(words_list: list[int]) -> bytes:
+    return endianessWordsToBytes(GlobalConfig.ENDIAN, words_list)
 
 #! deprecated
 beWordsToBytes = wordsToBytes
@@ -227,7 +228,7 @@ bannedEscapeCharacters = {
 
 escapeCharactersSpecialCases = {0x1B, 0x8C, 0x8D}
 
-def decodeString(buf: bytearray, offset: int, stringEncoding: str) -> tuple[list[str], int]:
+def decodeString(buf: bytes, offset: int, stringEncoding: str) -> tuple[list[str], int]:
     result = []
 
     dst = bytearray()

--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -46,15 +46,18 @@ def isStdoutRedirected() -> bool:
 def getStrHash(byte_array: bytes) -> str:
     return str(hashlib.md5(byte_array).hexdigest())
 
-def writeBytearrayToFile(filepath: Path, array_of_bytes: bytes):
+def writeBytesToFile(filepath: Path, array_of_bytes: bytes):
     with filepath.open(mode="wb") as f:
         f.write(array_of_bytes)
 
-def readFileAsBytearray(filepath: Path) -> bytes:
+#! deprecated
+writeBytearrayToFile = writeBytesToFile
+
+def readFileAsBytearray(filepath: Path) -> bytearray:
     if not filepath.exists():
-        return bytes(0)
+        return bytearray(0)
     with filepath.open(mode="rb") as f:
-        return bytes(f.read())
+        return bytearray(f.read())
 
 def readFile(filepath: Path) -> list[str]:
     with filepath.open() as f:

--- a/spimdisasm/elf32/Elf32Dyns.py
+++ b/spimdisasm/elf32/Elf32Dyns.py
@@ -29,7 +29,7 @@ class Elf32DynEntry:
         return self.val
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32DynEntry:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32DynEntry:
         entryFormat = common.GlobalConfig.ENDIAN.toFormatString() + "II"
         unpacked = struct.unpack_from(entryFormat, array_of_bytes, offset)
 
@@ -41,7 +41,7 @@ class Elf32DynEntry:
 
 
 class Elf32Dyns:
-    def __init__(self, array_of_bytes: bytearray, offset: int, rawSize: int):
+    def __init__(self, array_of_bytes: bytes, offset: int, rawSize: int):
         self.dyns: list[Elf32DynEntry] = list()
         self.offset: int = offset
         self.rawSize: int = rawSize

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -159,13 +159,13 @@ class Elf32File:
             self.got = Elf32GlobalOffsetTable(array_of_bytes, entry.offset, entry.size)
         elif sectionEntryName == ".interp":
             # strings with names of dynamic libraries
-            common.Utils.printVerbose(f"Unhandled SYMTAB found: '{sectionEntryName}'")
+            common.Utils.printVerbose(f"Unhandled PROGBITS found: '{sectionEntryName}'")
         elif sectionEntryName == ".MIPS.stubs":
             # ?
-            common.Utils.printVerbose(f"Unhandled SYMTAB found: '{sectionEntryName}'")
+            common.Utils.printVerbose(f"Unhandled PROGBITS found: '{sectionEntryName}'")
         elif sectionEntryName == ".init":
             # ?
-            common.Utils.printVerbose(f"Unhandled SYMTAB found: '{sectionEntryName}'")
+            common.Utils.printVerbose(f"Unhandled PROGBITS found: '{sectionEntryName}'")
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint(f"Unhandled PROGBITS found: '{sectionEntryName}'", entry, "\n")
 

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -21,7 +21,7 @@ from .Elf32Rels import Elf32Rels
 
 
 class Elf32File:
-    def __init__(self, array_of_bytes: bytearray):
+    def __init__(self, array_of_bytes: bytes):
         self.header = Elf32Header.fromBytearray(array_of_bytes)
         # print(self.header)
 
@@ -140,10 +140,10 @@ class Elf32File:
             common.GlobalConfig.ARCHLEVEL = common.ArchLevel.MIPS64R2
 
 
-    def _processSection_NULL(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_NULL(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         pass
 
-    def _processSection_PROGBITS(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_PROGBITS(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         fileSecType = common.FileSectionType.fromStr(sectionEntryName)
         smallFileSecType = common.FileSectionType.fromSmallStr(sectionEntryName)
 
@@ -169,13 +169,13 @@ class Elf32File:
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint(f"Unhandled PROGBITS found: '{sectionEntryName}'", entry, "\n")
 
-    def _processSection_SYMTAB(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_SYMTAB(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".symtab":
             self.symtab = Elf32Syms(array_of_bytes, entry.offset, entry.size)
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled SYMTAB found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_STRTAB(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_STRTAB(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".strtab":
             self.strtab = Elf32StringTable(array_of_bytes, entry.offset, entry.size)
         elif sectionEntryName == ".dynstr":
@@ -185,25 +185,25 @@ class Elf32File:
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled STRTAB found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_RELA(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_RELA(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_HASH(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_HASH(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_DYNAMIC(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_DYNAMIC(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".dynamic":
             self.dynamic = Elf32Dyns(array_of_bytes, entry.offset, entry.size)
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled DYNAMIC found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_NOTE(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_NOTE(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_NOBITS(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_NOBITS(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".bss":
             self.nobits = entry
         if sectionEntryName == ".sbss":
@@ -211,7 +211,7 @@ class Elf32File:
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled NOBITS found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_REL(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_REL(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName.startswith(".rel."):
             fileSecType = common.FileSectionType.fromStr(sectionEntryName[4:])
             if fileSecType != common.FileSectionType.Invalid:
@@ -221,53 +221,53 @@ class Elf32File:
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled REL found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_DYNSYM(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_DYNSYM(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".dynsym":
             self.dynsym = Elf32Syms(array_of_bytes, entry.offset, entry.size)
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled DYNSYM found: ", sectionEntryName, entry, "\n")
 
 
-    def _processSection_MIPS_LIBLIST(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_LIBLIST(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_MSYM(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_MSYM(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_CONFLICT(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_CONFLICT(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_GPTAB(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_GPTAB(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_DEBUG(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_DEBUG(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_REGINFO(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_REGINFO(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         if sectionEntryName == ".reginfo":
             self.reginfo = Elf32RegInfo.fromBytearray(array_of_bytes, entry.offset)
         elif common.GlobalConfig.VERBOSE:
             common.Utils.eprint("Unhandled MIPS_REGINFO found: ", sectionEntryName, entry, "\n")
 
-    def _processSection_MIPS_OPTIONS(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_OPTIONS(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_SYMBOL_LIB(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_SYMBOL_LIB(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
-    def _processSection_MIPS_ABIFLAGS(self, array_of_bytes: bytearray, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
+    def _processSection_MIPS_ABIFLAGS(self, array_of_bytes: bytes, entry: Elf32SectionHeaderEntry, sectionEntryName: str) -> None:
         # ?
         pass
 
 
-    _sectionProcessorCallbacks: dict[int, Callable[[Elf32File, bytearray, Elf32SectionHeaderEntry, str], None]] = {
+    _sectionProcessorCallbacks: dict[int, Callable[[Elf32File, bytes, Elf32SectionHeaderEntry, str], None]] = {
         Elf32SectionHeaderType.NULL.value: _processSection_NULL,
         Elf32SectionHeaderType.PROGBITS.value: _processSection_PROGBITS,
         Elf32SectionHeaderType.SYMTAB.value: _processSection_SYMTAB,

--- a/spimdisasm/elf32/Elf32GlobalOffsetTable.py
+++ b/spimdisasm/elf32/Elf32GlobalOffsetTable.py
@@ -27,7 +27,7 @@ class GotEntry:
 
 
 class Elf32GlobalOffsetTable:
-    def __init__(self, array_of_bytes: bytearray, offset: int, rawSize: int):
+    def __init__(self, array_of_bytes: bytes, offset: int, rawSize: int):
         self.entries: list[int] = list()
         self.offset: int = offset
         self.rawSize: int = rawSize

--- a/spimdisasm/elf32/Elf32Header.py
+++ b/spimdisasm/elf32/Elf32Header.py
@@ -48,7 +48,7 @@ class Elf32Identifier:
 
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32Identifier:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32Identifier:
         identFormat = "16B"
         ident = list(struct.unpack_from(identFormat, array_of_bytes, 0 + offset))
 
@@ -90,7 +90,7 @@ class Elf32Header:
                                             # 0x34
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32Header:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32Header:
         identifier = Elf32Identifier.fromBytearray(array_of_bytes, offset)
 
         dataEncoding = identifier.getDataEncoding()

--- a/spimdisasm/elf32/Elf32RegInfo.py
+++ b/spimdisasm/elf32/Elf32RegInfo.py
@@ -19,7 +19,7 @@ class Elf32RegInfo:
                                          # 0x18
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32RegInfo:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32RegInfo:
         gprFormat = common.GlobalConfig.ENDIAN.toFormatString() + "I"
         gpr = struct.unpack_from(gprFormat, array_of_bytes, 0 + offset)[0]
         # print(gpr)

--- a/spimdisasm/elf32/Elf32Rels.py
+++ b/spimdisasm/elf32/Elf32Rels.py
@@ -26,7 +26,7 @@ class Elf32RelEntry:
         return self.info & 0xFF
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32RelEntry:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32RelEntry:
         entryFormat = common.GlobalConfig.ENDIAN.toFormatString() + "II"
         unpacked = struct.unpack_from(entryFormat, array_of_bytes, offset)
 
@@ -34,7 +34,7 @@ class Elf32RelEntry:
 
 
 class Elf32Rels:
-    def __init__(self, sectionName: str, array_of_bytes: bytearray, offset: int, rawSize: int):
+    def __init__(self, sectionName: str, array_of_bytes: bytes, offset: int, rawSize: int):
         self.sectionName = sectionName
         self.relocations: list[Elf32RelEntry] = list()
         self.offset: int = offset

--- a/spimdisasm/elf32/Elf32SectionHeaders.py
+++ b/spimdisasm/elf32/Elf32SectionHeaders.py
@@ -29,7 +29,7 @@ class Elf32SectionHeaderEntry:
                                 # 0x28
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32SectionHeaderEntry:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32SectionHeaderEntry:
         headerFormat = common.GlobalConfig.ENDIAN.toFormatString() + "10I"
         unpacked = struct.unpack_from(headerFormat, array_of_bytes, offset)
 
@@ -37,7 +37,7 @@ class Elf32SectionHeaderEntry:
 
 
 class Elf32SectionHeaders:
-    def __init__(self, array_of_bytes: bytearray, shoff: int, shnum: int):
+    def __init__(self, array_of_bytes: bytes, shoff: int, shnum: int):
         self.sections: list[Elf32SectionHeaderEntry] = list()
         self.shoff: int = shoff
         self.shnum: int = shnum

--- a/spimdisasm/elf32/Elf32StringTable.py
+++ b/spimdisasm/elf32/Elf32StringTable.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 # a.k.a. strtab (string table)
 class Elf32StringTable:
-    def __init__(self, array_of_bytes: bytearray, offset: int, rawsize: int):
-        self.strings: bytearray = array_of_bytes[offset:offset+rawsize]
+    def __init__(self, array_of_bytes: bytes, offset: int, rawsize: int):
+        self.strings: bytes = array_of_bytes[offset:offset+rawsize]
         self.offset: int = offset
         self.rawsize: int = rawsize
 

--- a/spimdisasm/elf32/Elf32Syms.py
+++ b/spimdisasm/elf32/Elf32Syms.py
@@ -31,7 +31,7 @@ class Elf32SymEntry:
         return self.info & 0xF
 
     @staticmethod
-    def fromBytearray(array_of_bytes: bytearray, offset: int = 0) -> Elf32SymEntry:
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32SymEntry:
         entryFormat = common.GlobalConfig.ENDIAN.toFormatString() + "IIIBBH"
         unpacked = struct.unpack_from(entryFormat, array_of_bytes, offset)
 
@@ -43,7 +43,7 @@ class Elf32SymEntry:
 
 
 class Elf32Syms:
-    def __init__(self, array_of_bytes: bytearray, offset: int, rawSize: int):
+    def __init__(self, array_of_bytes: bytes, offset: int, rawSize: int):
         self.symbols: list[Elf32SymEntry] = list()
         self.offset: int = offset
         self.rawSize: int = rawSize

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -123,7 +123,7 @@ def getOutputPath(inputPath: Path, textOutput: Path, dataOutput: Path, sectionTy
 
     return outputFilePath
 
-def getProcessedSections(context: common.Context, elfFile: elf32.Elf32File, array_of_bytes: bytearray, inputPath: Path, textOutput: Path, dataOutput: Path) -> tuple[dict[common.FileSectionType, list[mips.sections.SectionBase]], dict[common.FileSectionType, list[Path]]]:
+def getProcessedSections(context: common.Context, elfFile: elf32.Elf32File, array_of_bytes: bytes, inputPath: Path, textOutput: Path, dataOutput: Path) -> tuple[dict[common.FileSectionType, list[mips.sections.SectionBase]], dict[common.FileSectionType, list[Path]]]:
     processedSegments: dict[common.FileSectionType, list[mips.sections.SectionBase]] = dict()
     segmentPaths: dict[common.FileSectionType, list[Path]] = dict()
 

--- a/spimdisasm/frontendCommon/FrontendUtilities.py
+++ b/spimdisasm/frontendCommon/FrontendUtilities.py
@@ -24,7 +24,7 @@ ProgressCallbackType = Callable[[int, str, int], None]
 _sLenLastLine = 80
 
 
-def getSplittedSections(context: common.Context, splits: common.FileSplitFormat, array_of_bytes: bytearray, inputPath: Path, textOutput: Path, dataOutput: Path) -> tuple[dict[common.FileSectionType, list[mips.sections.SectionBase]], dict[common.FileSectionType, list[Path]]]:
+def getSplittedSections(context: common.Context, splits: common.FileSplitFormat, array_of_bytes: bytes, inputPath: Path, textOutput: Path, dataOutput: Path) -> tuple[dict[common.FileSectionType, list[mips.sections.SectionBase]], dict[common.FileSectionType, list[Path]]]:
     processedFiles: dict[common.FileSectionType, list[mips.sections.SectionBase]] = {
         common.FileSectionType.Text: [],
         common.FileSectionType.Data: [],
@@ -211,8 +211,7 @@ def writeFunctionInfoCsv(processedFiles: dict[common.FileSectionType, list[mips.
                     topbits = instr.getRaw() & 0xFC000000
 
                     bitswordlist.append(topbits)
-                bitbytelist = bytearray([0]*len(bitswordlist)*4)
-                common.Utils.endianessWordsToBytes(common.Utils.InputEndian.BIG, bitswordlist, bitbytelist)
+                bitbytelist = common.Utils.endianessWordsToBytes(common.Utils.InputEndian.BIG, bitswordlist)
 
                 f.write(common.Utils.getStrHash(bitbytelist))
                 f.write(",")

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -17,7 +17,7 @@ from . import symbols
 from . import FunctionRodataEntry
 
 
-def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_bytes: bytearray, context: common.Context) -> sections.SectionBase:
+def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_bytes: bytes, context: common.Context) -> sections.SectionBase:
     offsetStart = splitEntry.offset
     offsetEnd = splitEntry.nextOffset
 

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -55,8 +55,7 @@ class FileBase(common.ElementBase):
         return output
 
     def getHash(self) -> str:
-        buffer = bytearray(4*len(self.words))
-        common.Utils.wordsToBytes(self.words, buffer)
+        buffer = common.Utils.wordsToBytes(self.words)
         return common.Utils.getStrHash(buffer)
 
 
@@ -180,8 +179,7 @@ class FileBase(common.ElementBase):
         else:
             if common.GlobalConfig.WRITE_BINARY:
                 if self.sizew > 0:
-                    buffer = bytearray(4*len(self.words))
-                    common.Utils.wordsToBytes(self.words, buffer)
+                    buffer = common.Utils.wordsToBytes(self.words)
                     common.Utils.writeBytearrayToFile(Path(filepath + self.sectionType.toStr()), buffer)
             with open(filepath + self.sectionType.toStr() + ".s", "w", encoding="utf-8") as f:
                 self.disassembleToFile(f)

--- a/spimdisasm/mips/MipsFileBase.py
+++ b/spimdisasm/mips/MipsFileBase.py
@@ -180,7 +180,7 @@ class FileBase(common.ElementBase):
             if common.GlobalConfig.WRITE_BINARY:
                 if self.sizew > 0:
                     buffer = common.Utils.wordsToBytes(self.words)
-                    common.Utils.writeBytearrayToFile(Path(filepath + self.sectionType.toStr()), buffer)
+                    common.Utils.writeBytesToFile(Path(filepath + self.sectionType.toStr()), buffer)
             with open(filepath + self.sectionType.toStr() + ".s", "w", encoding="utf-8") as f:
                 self.disassembleToFile(f)
 

--- a/spimdisasm/mips/MipsFileSplits.py
+++ b/spimdisasm/mips/MipsFileSplits.py
@@ -16,7 +16,7 @@ from . import FileBase, createEmptyFile
 
 
 class FileSplits(FileBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None, splitsData: common.FileSplitFormat|None=None, relocSection: sections.SectionRelocZ64|None=None):
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytes, segmentVromStart: int, overlayCategory: str|None, splitsData: common.FileSplitFormat|None=None, relocSection: sections.SectionRelocZ64|None=None):
         super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Unknown, segmentVromStart, overlayCategory)
 
         self.sectionsDict: dict[common.FileSectionType, dict[str, sections.SectionBase]] = {
@@ -100,8 +100,7 @@ class FileSplits(FileBase):
         for sectDict in self.sectionsDict.values():
             for section in sectDict.values():
                 words += section.words
-        buffer = bytearray(4*len(words))
-        common.Utils.wordsToBytes(words, buffer)
+        buffer = common.Utils.wordsToBytes(words)
         return common.Utils.getStrHash(buffer)
 
     def analyze(self):

--- a/spimdisasm/mips/sections/MipsSectionData.py
+++ b/spimdisasm/mips/sections/MipsSectionData.py
@@ -13,7 +13,7 @@ from . import SectionBase
 
 
 class SectionData(SectionBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytes, segmentVromStart: int, overlayCategory: str|None):
         if common.GlobalConfig.ENDIAN_DATA is not None:
             words = common.Utils.endianessBytesToWords(common.GlobalConfig.ENDIAN_DATA, array_of_bytes, vromStart, vromEnd)
         else:

--- a/spimdisasm/mips/sections/MipsSectionRelocZ64.py
+++ b/spimdisasm/mips/sections/MipsSectionRelocZ64.py
@@ -43,7 +43,7 @@ class RelocEntry:
 
 
 class SectionRelocZ64(SectionBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytes, segmentVromStart: int, overlayCategory: str|None):
         super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Reloc, segmentVromStart, overlayCategory)
 
         self.seekup = self.words[-1]

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -15,15 +15,14 @@ from . import SectionBase
 
 
 class SectionRodata(SectionBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytes, segmentVromStart: int, overlayCategory: str|None):
         if common.GlobalConfig.ENDIAN_RODATA is not None:
             words = common.Utils.endianessBytesToWords(common.GlobalConfig.ENDIAN_RODATA, array_of_bytes, vromStart, vromEnd)
         else:
             words = common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd)
         super().__init__(context, vromStart, vromEnd, vram, filename, words, common.FileSectionType.Rodata, segmentVromStart, overlayCategory)
 
-        self.bytes: bytearray = bytearray(self.sizew*4)
-        common.Utils.wordsToBytes(self.words, self.bytes)
+        self.bytes: bytes = common.Utils.wordsToBytes(self.words)
 
 
     def _stringGuesser(self, contextSym: common.ContextSymbol, localOffset: int) -> bool:

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -16,7 +16,7 @@ from . import SectionBase
 
 
 class SectionText(SectionBase):
-    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytearray, segmentVromStart: int, overlayCategory: str|None):
+    def __init__(self, context: common.Context, vromStart: int, vromEnd: int, vram: int, filename: str, array_of_bytes: bytes, segmentVromStart: int, overlayCategory: str|None):
         super().__init__(context, vromStart, vromEnd, vram, filename, common.Utils.bytesToWords(array_of_bytes, vromStart, vromEnd), common.FileSectionType.Text, segmentVromStart, overlayCategory)
 
         self.instrCat: rabbitizer.Enum = rabbitizer.InstrCategory.CPU

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -389,8 +389,7 @@ class SymbolBase(common.ElementBase):
     def getNthWordAsString(self, i: int) -> tuple[str, int]:
         localOffset = 4*i
 
-        buffer = bytearray(4*len(self.words))
-        common.Utils.wordsToBytes(self.words, buffer)
+        buffer = common.Utils.wordsToBytes(self.words)
         decodedStrings, rawStringSize = common.Utils.decodeString(buffer, localOffset, self.stringEncoding)
 
         # To be a valid aligned string, the next word-aligned bytes needs to be zero


### PR DESCRIPTION
- Actually add `py.typed` to `pyproject.toml`
- Use `bytearray` as little as possible
- `writeBytearrayToFile` is now deprecated, use `writeBytesToFile` instead