### PR TITLE
1.15.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.15.2"
+version = "1.15.3"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__ = (1, 15, 2)
+__version_info__ = (1, 15, 3)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 


### PR DESCRIPTION
- Don't use append the section name if it is known when disassembling elfs
  - This special cases the sections `.text`, `.data`, `.rodata` and `.bss`.
  - Avoids the redundant `filename_.text/` naming scheme