### PR TITLE
1.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.16.5"
+version = "1.16.6.dev0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.16.6.dev0"
+version = "1.16.6"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.16.6"
+version = "1.17.0"
 description = "MIPS disassembler"
 # license = "MIT"
 readme = "README.md"

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 16, 6)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 16, 6)
+__version_info__: tuple[int, int, int] = (1, 17, 0)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 16, 5)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__: tuple[int, int, int] = (1, 16, 6)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -516,7 +516,7 @@ class ContextSymbol:
             return f"{self.getName()} - 0x{self.address - address:X}"
         return f"{self.getName()} + 0x{address - self.address:X}"
 
-    def getLabelMacro(self) -> str|None:
+    def getLabelMacro(self, isInMiddleLabel: bool=False) -> str|None:
         if not GlobalConfig.ASM_USE_SYMBOL_LABEL:
             return None
         label = ""
@@ -530,7 +530,10 @@ class ContextSymbol:
         if currentType == SymbolSpecialType.jumptablelabel:
             label += GlobalConfig.ASM_JTBL_LABEL
         elif self.sectionType == FileSectionType.Text:
-            label += GlobalConfig.ASM_TEXT_LABEL
+            if isInMiddleLabel:
+                label += GlobalConfig.ASM_TEXT_ALT_LABEL
+            else:
+                label += GlobalConfig.ASM_TEXT_LABEL
         else:
             label += GlobalConfig.ASM_DATA_LABEL
         return label

--- a/spimdisasm/common/ElementBase.py
+++ b/spimdisasm/common/ElementBase.py
@@ -94,7 +94,7 @@ class ElementBase:
     def getLabelFromSymbol(self, sym: ContextSymbol|None, symName: str|None) -> str:
         "Generates a glabel for the passed symbol, including an optional index value if it was set and it is enabled in the GlobalConfig"
         if sym is not None:
-            label = sym.getLabelMacro()
+            label = sym.getLabelMacro(isInMiddleLabel=False)
             if label is None:
                 return ""
             label += f" {symName or sym.getName()}"

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -223,6 +223,7 @@ class GlobalConfigType:
     ASM_REFERENCEE_SYMBOLS: bool = False
 
     ASM_TEXT_LABEL: str = "glabel"
+    ASM_TEXT_ALT_LABEL: str = "glabel"
     ASM_JTBL_LABEL: str = "jlabel"
     ASM_DATA_LABEL: str = "dlabel"
     ASM_USE_SYMBOL_LABEL: bool = True
@@ -343,6 +344,7 @@ A C string must start at a 0x4-aligned region, which is '\\0' terminated and pad
         miscConfig.add_argument("--asm-referencee-symbols", help=f"Toggle glabel count comment. Defaults to {self.ASM_REFERENCEE_SYMBOLS}", action=Utils.BooleanOptionalAction)
 
         miscConfig.add_argument("--asm-text-label", help=f"Changes the label used to declare functions. Defaults to {self.ASM_TEXT_LABEL}")
+        miscConfig.add_argument("--asm-text-alt-label", help=f"Changes the label used to declare symbols in the middle of functions. Defaults to {self.ASM_TEXT_ALT_LABEL}")
         miscConfig.add_argument("--asm-jtbl-label", help=f"Changes the label used to declare jumptable labels. Defaults to {self.ASM_JTBL_LABEL}")
         miscConfig.add_argument("--asm-data-label", help=f"Changes the label used to declare data symbols. Defaults to {self.ASM_DATA_LABEL}")
         miscConfig.add_argument("--asm-use-symbol-label", help=f"Toggles the use of labels for symbols. Defaults to {self.ASM_USE_SYMBOL_LABEL}", action=Utils.BooleanOptionalAction)
@@ -500,6 +502,8 @@ A C string must start at a 0x4-aligned region, which is '\\0' terminated and pad
 
         if args.asm_text_label:
             self.ASM_TEXT_LABEL = args.asm_text_label
+        if args.asm_text_alt_label:
+            self.ASM_TEXT_ALT_LABEL = args.asm_text_alt_label
         if args.asm_jtbl_label:
             self.ASM_JTBL_LABEL = args.asm_jtbl_label
         if args.asm_data_label:

--- a/spimdisasm/common/Relocation.py
+++ b/spimdisasm/common/Relocation.py
@@ -203,3 +203,6 @@ class RelocationInfo:
             output += f" (global reloc)"
         output += f"{GlobalConfig.LINE_ENDS}"
         return output
+
+    def isRelocNone(self) -> bool:
+        return self.relocType == RelocType.MIPS_NONE

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -328,6 +328,7 @@ def injectAllElfSymbols(context: common.Context, elfFile: elf32.Elf32File, proce
         # Inject symbols from the reloc table referenced in each section
         if elfFile.header.type == elf32.Elf32ObjectFileType.REL.value:
             for sectionName, relocs in elfFile.relPerName.items():
+                subSegment = sectionsPerName.get(sectionName, None)
                 for rel in relocs:
                     symbolEntry = elfFile.symtab[rel.rSym]
                     symbolName = elfFile.strtab[symbolEntry.name]
@@ -336,7 +337,9 @@ def injectAllElfSymbols(context: common.Context, elfFile: elf32.Elf32File, proce
                         if symbolName == "":
                             continue
 
-                    subSegment = sectionsPerName[sectionName]
+                    if subSegment is None:
+                        common.Utils.eprint(f"Warning: reloc '{rel}' references unhandled section '{sectionName}'")
+                        continue
 
                     relocVrom = subSegment.vromStart + rel.offset
                     relocInfo = context.addGlobalReloc(relocVrom, common.RelocType(rel.rType), symbolName)

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -374,6 +374,9 @@ class SymbolBase(common.ElementBase):
         # .elf relocated symbol
         relocInfo = self.getReloc(localOffset, None)
         if relocInfo is not None:
+            if relocInfo.isRelocNone():
+                # 
+                pass
             if relocInfo.staticReference is not None:
                 relocVram = relocInfo.staticReference.sectionVram + w
                 contextSym = self.getSymbol(relocVram, checkUpperLimit=False)

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -106,7 +106,7 @@ class SymbolBase(common.ElementBase):
         label = ""
         if contextSym is not None:
             label = common.GlobalConfig.LINE_ENDS
-            symLabel = contextSym.getLabelMacro()
+            symLabel = contextSym.getLabelMacro(isInMiddleLabel=True)
             if symLabel is not None:
                 label += f"{symLabel} {contextSym.getName()}{common.GlobalConfig.LINE_ENDS}"
                 if common.GlobalConfig.ASM_DATA_SYM_AS_LABEL:

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -375,9 +375,9 @@ class SymbolBase(common.ElementBase):
         relocInfo = self.getReloc(localOffset, None)
         if relocInfo is not None:
             if relocInfo.isRelocNone():
-                # 
+                # If the reloc type is none then use the raw number instead
                 pass
-            if relocInfo.staticReference is not None:
+            elif relocInfo.staticReference is not None:
                 relocVram = relocInfo.staticReference.sectionVram + w
                 contextSym = self.getSymbol(relocVram, checkUpperLimit=False)
                 if contextSym is not None:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -649,7 +649,7 @@ class SymbolFunction(SymbolText):
         labelSymType = labelSym.getTypeSpecial()
         if labelSymType == common.SymbolSpecialType.function or (labelSymType == common.SymbolSpecialType.jumptablelabel and not migrate):
             label = labelSym.getReferenceeSymbols()
-            labelMacro = labelSym.getLabelMacro()
+            labelMacro = labelSym.getLabelMacro(isInMiddleLabel=True)
             if labelMacro is not None:
                 label += f"{labelMacro} {labelSym.getName()}{common.GlobalConfig.LINE_ENDS}"
             if common.GlobalConfig.ASM_TEXT_FUNC_AS_LABEL:

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -604,7 +604,7 @@ class SymbolFunction(SymbolText):
             return None
 
         relocInfo = self.getReloc(instrOffset, instr)
-        if relocInfo is not None:
+        if relocInfo is not None and not relocInfo.isRelocNone():
             return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
 
         if instr.isBranch() or instr.isUnconditionalBranch():

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -344,9 +344,9 @@ class SymbolFunction(SymbolText):
                 if instr.canBeHi():
                     loInstr = self.instructions[self.instrAnalyzer.hiToLowDict[instrOffset] // 4]
 
-                generatedStr = self.generateHiLoConstantStr(constant, instr, loInstr)
-                if generatedStr is not None:
-                    self.relocs[instrOffset] = common.RelocationInfo(common.RelocType.MIPS_NONE, generatedStr)
+                generatedReloc = self._generateHiLoConstantReloc(constant, instr, loInstr)
+                if generatedReloc is not None:
+                    self.relocs[instrOffset] = generatedReloc
 
         for instrOffset, targetVram in self.instrAnalyzer.funcCallInstrOffsets.items():
             funcSym = self.getSymbol(targetVram, tryPlusOffset=False)
@@ -570,18 +570,18 @@ class SymbolFunction(SymbolText):
             del self.instructions[first_nop:]
         return was_updated
 
-    def generateHiLoConstantStr(self, constantValue: int, currentInstr: rabbitizer.Instruction, loInstr: rabbitizer.Instruction|None) -> str|None:
+    def _generateHiLoConstantReloc(self, constantValue: int, currentInstr: rabbitizer.Instruction, loInstr: rabbitizer.Instruction|None) -> common.RelocationInfo|None:
         if loInstr is None:
             if currentInstr.canBeHi():
-                return f"(0x{constantValue:X} >> 16)"
+                return common.RelocationInfo(common.RelocType.CUSTOM_CONSTANT_HI, f"0x{constantValue:X}")
             return None
 
         if loInstr.canBeLo():
             if loInstr.isUnsigned():
                 if currentInstr.canBeHi():
-                    return f"(0x{constantValue:X} >> 16)"
+                    return common.RelocationInfo(common.RelocType.CUSTOM_CONSTANT_HI, f"0x{constantValue:X}")
                 if currentInstr.canBeLo():
-                    return f"(0x{constantValue:X} & 0xFFFF)"
+                    return common.RelocationInfo(common.RelocType.CUSTOM_CONSTANT_LO, f"0x{constantValue:X}")
                 return None
             else:
                 hiHalf = constantValue >> 16
@@ -589,9 +589,9 @@ class SymbolFunction(SymbolText):
                 if loHalf < 0x8000:
                     # positive lo half
                     if currentInstr.canBeHi():
-                        return f"(0x{constantValue:X} >> 16)"
+                        return common.RelocationInfo(common.RelocType.CUSTOM_CONSTANT_HI, f"0x{constantValue:X}")
                     if currentInstr.canBeLo():
-                        return f"(0x{constantValue:X} & 0xFFFF)"
+                        return common.RelocationInfo(common.RelocType.CUSTOM_CONSTANT_LO, f"0x{constantValue:X}")
                 else:
                     # negative lo half
                     # loHalf = rabbitizer.Utils.from2Complement(loHalf, 16)
@@ -620,11 +620,15 @@ class SymbolFunction(SymbolText):
         if instr.hasOperandAlias(rabbitizer.OperandType.cpu_immediate):
             if instrOffset in self.instrAnalyzer.symbolInstrOffset:
                 address = self.instrAnalyzer.symbolInstrOffset[instrOffset]
-                return self.generateHiLoConstantStr(address, instr, instr)
+                relocInfo = self._generateHiLoConstantReloc(address, instr, instr)
+                if relocInfo is not None:
+                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
 
-            if instr.canBeHi():
+            elif instr.canBeHi():
                 # Unpaired LUI
-                return self.generateHiLoConstantStr(instr.getProcessedImmediate()<<16, instr, None)
+                relocInfo = self._generateHiLoConstantReloc(instr.getProcessedImmediate()<<16, instr, None)
+                if relocInfo is not None:
+                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
 
         return None
 


### PR DESCRIPTION
- Allow using `MIPS_NONE` reloc type as a way to avoid symbolizing a reference and use the raw value instead.
- Allow using a different label for symbols in the middle of functions.
  - Useful for setting alternative entry points for handwritten functions.
  - It can be used by setting the `ASM_TEXT_ALT_LABEL`.
- Fix `elfObjDisasm` crashing if a reloc section references an unhandled section like `.pdr`.