### PR TITLE
Allow .ovl entries in file splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- File splits can now contain reloc sections (`.ovl` or `.reloc`).
+
 ## [1.19.0] - 2023-12-04
 
 ### Added

--- a/spimdisasm/common/FileSectionType.py
+++ b/spimdisasm/common/FileSectionType.py
@@ -80,6 +80,7 @@ gNameToSectionType = {
     ".rodata":  FileSectionType.Rodata,
     ".rdata":   FileSectionType.Rodata,
     ".bss":     FileSectionType.Bss,
+    ".ovl":     FileSectionType.Reloc,
     ".reloc":   FileSectionType.Reloc,
     ".end":     FileSectionType.End,
     ".dummy":   FileSectionType.Dummy,

--- a/spimdisasm/frontendCommon/FrontendUtilities.py
+++ b/spimdisasm/frontendCommon/FrontendUtilities.py
@@ -42,6 +42,8 @@ def getSplittedSections(context: common.Context, splits: common.FileSplitFormat,
             outputPath = dataOutput
         elif row.section == common.FileSectionType.Bss:
             outputPath = dataOutput
+        elif row.section == common.FileSectionType.Reloc:
+            outputPath = dataOutput
         elif row.section == common.FileSectionType.Dummy:
             # Ignore dummy sections
             continue

--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -46,6 +46,8 @@ def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_byte
     elif splitEntry.section == common.FileSectionType.Bss:
         bssVramEnd = splitEntry.vram + offsetEnd - offsetStart
         f = sections.SectionBss(context, offsetStart, offsetEnd, splitEntry.vram, bssVramEnd, splitEntry.fileName, 0, None)
+    elif splitEntry.section == common.FileSectionType.Reloc:
+        f = sections.SectionRelocZ64(context, offsetStart, offsetEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
     else:
         common.Utils.eprint("Error! Section not set!")
         exit(-1)


### PR DESCRIPTION
Overlay file splits need some way to specify the end of the rodata section, since the reloc section is between rodata and bss. We could add a dummy section there instead, but it's nice to use `.ovl` especially when autogenerating these from a mapfile.