### PR TITLE
Add segment vrom start to file split offset

### DIFF
--- a/spimdisasm/mips/FilesHandlers.py
+++ b/spimdisasm/mips/FilesHandlers.py
@@ -17,7 +17,7 @@ from . import symbols
 from . import FunctionRodataEntry
 
 
-def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_bytes: bytes, context: common.Context) -> sections.SectionBase:
+def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_bytes: bytes, context: common.Context, vromStart: int = 0) -> sections.SectionBase:
     offsetStart = splitEntry.offset
     offsetEnd = splitEntry.nextOffset
 
@@ -31,23 +31,26 @@ def createSectionFromSplitEntry(splitEntry: common.FileSplitEntry, array_of_byte
     elif offsetStart >= 0:
         common.Utils.printVerbose(f"Parsing since offset 0x{offsetStart:02X}")
 
+    sectionStart = vromStart + offsetStart
+    sectionEnd = vromStart + offsetEnd
+
     common.Utils.printVerbose(f"Using VRAM {splitEntry.vram:08X}")
     vram = splitEntry.vram
 
     f: sections.SectionBase
     if splitEntry.section == common.FileSectionType.Text:
-        f = sections.SectionText(context, offsetStart, offsetEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
+        f = sections.SectionText(context, sectionStart, sectionEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
         if splitEntry.isRsp:
             f.instrCat = rabbitizer.InstrCategory.RSP
     elif splitEntry.section == common.FileSectionType.Data:
-        f = sections.SectionData(context, offsetStart, offsetEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
+        f = sections.SectionData(context, sectionStart, sectionEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
     elif splitEntry.section == common.FileSectionType.Rodata:
-        f = sections.SectionRodata(context, offsetStart, offsetEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
+        f = sections.SectionRodata(context, sectionStart, sectionEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
     elif splitEntry.section == common.FileSectionType.Bss:
         bssVramEnd = splitEntry.vram + offsetEnd - offsetStart
-        f = sections.SectionBss(context, offsetStart, offsetEnd, splitEntry.vram, bssVramEnd, splitEntry.fileName, 0, None)
+        f = sections.SectionBss(context, sectionStart, sectionEnd, splitEntry.vram, bssVramEnd, splitEntry.fileName, 0, None)
     elif splitEntry.section == common.FileSectionType.Reloc:
-        f = sections.SectionRelocZ64(context, offsetStart, offsetEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
+        f = sections.SectionRelocZ64(context, sectionStart, sectionEnd, vram, splitEntry.fileName, array_of_bytes, 0, None)
     else:
         common.Utils.eprint("Error! Section not set!")
         exit(-1)

--- a/spimdisasm/mips/MipsFileSplits.py
+++ b/spimdisasm/mips/MipsFileSplits.py
@@ -74,7 +74,7 @@ class FileSplits(FileBase):
             # if self.vram is None:
             #     self.vram = splitEntry.vram
 
-            f = FilesHandlers.createSectionFromSplitEntry(splitEntry, array_of_bytes, context)
+            f = FilesHandlers.createSectionFromSplitEntry(splitEntry, array_of_bytes, context, vromStart)
             f.parent = self
             f.setCommentOffset(splitEntry.offset)
 


### PR DESCRIPTION
Currently the `offset` in a file splits csv is interpreted as an absolute vrom address, but the name suggests it should be an offset relative to the start of the segment.

Would this break any users? z64OvlDisasm.py in zelda64_compare always passes 0 for FileSplits vromStart.