### PR TITLE
1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2024-03-25
+
 ### Added
 
 - Add `EEGCC` compiler option.
@@ -1466,7 +1468,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
-[1.23.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.1...1.23.1
+[1.24.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.1...1.24.0
+[1.23.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.0...1.23.1
 [1.23.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.22.0...1.23.0
 [1.22.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.21.1...1.22.0
 [1.21.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.20.1...1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `EEGCC` compiler option.
 
+### Changed
+
+- Emit `.align 3` directives for strings for `EEGCC`.
+
 ## [1.23.1] - 2024-03-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Emit `.align 3` directives for strings for `EEGCC`.
+- Emit `.align 3` directives for strings for `EEGCC` compiler.
+- Emit `.align 3` directives for functions for `EEGCC` compiler.
 
 ## [1.23.1] - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Emit `.align 3` directives for strings for `EEGCC` compiler.
 - Emit `.align 3` directives for functions for `EEGCC` compiler.
+- Change default compiler to `GCC`.
 
 ## [1.23.1] - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Emit `.align 3` directives for strings for `EEGCC` compiler.
 - Emit `.align 3` directives for functions for `EEGCC` compiler.
-- Change default compiler to `GCC`.
+- Refactor `Compiler` to make implementing per-compiler differences more easily.
 
 ## [1.23.1] - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `EEGCC` compiler option.
+- Add `KMC` compiler option.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EEGCC` compiler option.
+
 ## [1.23.1] - 2024-03-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.23.1,<2.0.0
+spimdisasm>=1.24.0,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.23.1"
+version = "1.23.2.dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.23.2.dev0"
+version = "1.24.0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 23, 1)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__: tuple[int, int, int] = (1, 23, 2)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 23, 2)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version_info__: tuple[int, int, int] = (1, 24, 0)
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/common/CompilerConfig.py
+++ b/spimdisasm/common/CompilerConfig.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2022-2024 Decompollaborate
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+
+
+@dataclasses.dataclass
+class CompilerProperties:
+    name: str
+    hasLateRodata: bool = False
+
+
+@enum.unique
+class Compiler(enum.Enum):
+    UNKNOWN = CompilerProperties("UNKNOWN")
+
+    # General GCC
+    GCC = CompilerProperties("GCC")
+
+    # N64
+    IDO = CompilerProperties("IDO", hasLateRodata=True)
+    KMC = CompilerProperties("KMC")
+    SN64 = CompilerProperties("SN64")
+
+    # iQue
+    EGCS = CompilerProperties("EGCS")
+
+    # PS1
+    PSYQ = CompilerProperties("PSYQ")
+
+    # PS2
+    MWCC = CompilerProperties("MWCC")
+    EEGCC = CompilerProperties("EEGCC")
+
+    @staticmethod
+    def fromStr(value: str) -> Compiler:
+        return compilerOptions.get(value, Compiler.UNKNOWN)
+
+
+compilerOptions: dict[str, Compiler] = {
+    x.name: x
+    for x in [
+        Compiler.GCC,
+        Compiler.IDO,
+        Compiler.KMC,
+        Compiler.SN64,
+        Compiler.EGCS,
+        Compiler.PSYQ,
+        Compiler.MWCC,
+        Compiler.EEGCC,
+    ]
+}

--- a/spimdisasm/common/CompilerConfig.py
+++ b/spimdisasm/common/CompilerConfig.py
@@ -12,11 +12,39 @@ import enum
 @dataclasses.dataclass
 class CompilerProperties:
     name: str
+
     hasLateRodata: bool = False
+
     prevAlign_double: int|None = None # TODO: Specifying 3 as the default should be harmless. Need to investigate.
     prevAlign_jumptable: int|None = None
     prevAlign_string: int|None = 2
     prevAlign_function: int|None = None
+
+    pairMultipleHiToSameLow: bool = True
+
+    allowRdataMigration: bool = False
+
+    bigAddendWorkaroundForMigratedFunctions: bool = True
+    """
+    Modern GAS can handle big addends (outside the 16-bits range) for the `%lo`
+    directive just fine, but old assemblers choke on them, so we truncate them
+    to said range when building with those assemblers.
+
+    Decomp projects usually use two assemblers:
+    - One to assemble unmigrated files, usually with modern GAS.
+    - Another one to assemble individual functions that get inserted into C
+      files, either with asm directives from the compiler (using the built-in
+      old assembler shipped with the old compiler) or with an external tools
+      (like asm-proc for IDO).
+
+    Modern GAS requires no addend truncation to produce matching output, so we
+    don't use the workaround for unmigrated asm files.
+
+    For migrated functions we need to know if the compiler uses modern GAS or
+    old GAS. If it uses modern GAS (like IDO projects), then this flag should
+    be turned off, but if the project uses its own old assembler (like most GCC
+    based projects) then this flag needs to be turned on.
+    """
 
 
 @enum.unique
@@ -27,15 +55,15 @@ class Compiler(enum.Enum):
     GCC = CompilerProperties("GCC", prevAlign_jumptable=3)
 
     # N64
-    IDO = CompilerProperties("IDO", hasLateRodata=True)
+    IDO = CompilerProperties("IDO", hasLateRodata=True, pairMultipleHiToSameLow=False, bigAddendWorkaroundForMigratedFunctions=False)
     KMC = CompilerProperties("KMC", prevAlign_jumptable=3)
-    SN64 = CompilerProperties("SN64", prevAlign_double=3, prevAlign_jumptable=3)
+    SN64 = CompilerProperties("SN64", prevAlign_double=3, prevAlign_jumptable=3, allowRdataMigration=True)
 
     # iQue
     EGCS = CompilerProperties("EGCS", prevAlign_jumptable=3)
 
     # PS1
-    PSYQ = CompilerProperties("PSYQ", prevAlign_double=3, prevAlign_jumptable=3)
+    PSYQ = CompilerProperties("PSYQ", prevAlign_double=3, prevAlign_jumptable=3, allowRdataMigration=True)
 
     # PS2
     MWCC = CompilerProperties("MWCC", prevAlign_jumptable=4)

--- a/spimdisasm/common/CompilerConfig.py
+++ b/spimdisasm/common/CompilerConfig.py
@@ -13,6 +13,10 @@ import enum
 class CompilerProperties:
     name: str
     hasLateRodata: bool = False
+    prevAlign_double: int|None = None # TODO: Specifying 3 as the default should be harmless. Need to investigate.
+    prevAlign_jumptable: int|None = None
+    prevAlign_string: int|None = 2
+    prevAlign_function: int|None = None
 
 
 @enum.unique
@@ -20,22 +24,22 @@ class Compiler(enum.Enum):
     UNKNOWN = CompilerProperties("UNKNOWN")
 
     # General GCC
-    GCC = CompilerProperties("GCC")
+    GCC = CompilerProperties("GCC", prevAlign_jumptable=3)
 
     # N64
     IDO = CompilerProperties("IDO", hasLateRodata=True)
-    KMC = CompilerProperties("KMC")
-    SN64 = CompilerProperties("SN64")
+    KMC = CompilerProperties("KMC", prevAlign_jumptable=3)
+    SN64 = CompilerProperties("SN64", prevAlign_double=3, prevAlign_jumptable=3)
 
     # iQue
-    EGCS = CompilerProperties("EGCS")
+    EGCS = CompilerProperties("EGCS", prevAlign_jumptable=3)
 
     # PS1
-    PSYQ = CompilerProperties("PSYQ")
+    PSYQ = CompilerProperties("PSYQ", prevAlign_double=3, prevAlign_jumptable=3)
 
     # PS2
-    MWCC = CompilerProperties("MWCC")
-    EEGCC = CompilerProperties("EEGCC")
+    MWCC = CompilerProperties("MWCC", prevAlign_jumptable=4)
+    EEGCC = CompilerProperties("EEGCC", prevAlign_jumptable=3, prevAlign_string=3, prevAlign_function=4)
 
     @staticmethod
     def fromStr(value: str) -> Compiler:

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -407,7 +407,7 @@ class ContextSymbol:
         return self.name.startswith(".")
 
     def isLateRodata(self) -> bool:
-        if GlobalConfig.COMPILER != Compiler.IDO:
+        if not GlobalConfig.COMPILER.value.hasLateRodata:
             # late rodata only exists in IDO world
             return False
         # if self.referenceCounter > 1: return False # ?

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -40,13 +40,13 @@ compilerOptions = {"IDO", "GCC", "SN64", "PSYQ", "EGCS", "MWCC", "EEGCC"}
 @enum.unique
 class Compiler(enum.Enum):
     UNKNOWN = None
-    IDO = "IDO"
-    GCC = "GCC"
-    SN64 = "SN64"
-    PSYQ = "PSYQ"
-    EGCS = "EGCS"
-    MWCC = "MWCC"
-    EEGCC = "EEGCC"
+    IDO = "IDO" # N64
+    GCC = "GCC" # N64
+    SN64 = "SN64" # N64
+    PSYQ = "PSYQ" # PS1
+    EGCS = "EGCS" # iQue
+    MWCC = "MWCC" # PS2
+    EEGCC = "EEGCC" # PS2
 
     @staticmethod
     def fromStr(value: str) -> Compiler:

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -35,16 +35,34 @@ class InputEndian(enum.Enum):
         raise ValueError(f"No struct format string available for : {self}")
 
 
-compilerOptions = {"IDO", "GCC", "SN64", "PSYQ", "EGCS", "MWCC", "EEGCC"}
+compilerOptions = {
+    "GCC",
+
+    # N64
+    "IDO",
+    "KMC",
+    "SN64",
+
+    # iQue
+    "EGCS",
+
+    # PS1
+    "PSYQ",
+
+    # PS2
+    "MWCC",
+    "EEGCC",
+}
 
 @enum.unique
 class Compiler(enum.Enum):
     UNKNOWN = None
+    GCC = "GCC" # General GCC
     IDO = "IDO" # N64
-    GCC = "GCC" # N64
+    KMC = "KMC" # N64
     SN64 = "SN64" # N64
-    PSYQ = "PSYQ" # PS1
     EGCS = "EGCS" # iQue
+    PSYQ = "PSYQ" # PS1
     MWCC = "MWCC" # PS2
     EEGCC = "EEGCC" # PS2
 

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -35,7 +35,7 @@ class InputEndian(enum.Enum):
         raise ValueError(f"No struct format string available for : {self}")
 
 
-compilerOptions = {"IDO", "GCC", "SN64", "PSYQ", "EGCS", "MWCC"}
+compilerOptions = {"IDO", "GCC", "SN64", "PSYQ", "EGCS", "MWCC", "EEGCC"}
 
 @enum.unique
 class Compiler(enum.Enum):
@@ -46,6 +46,7 @@ class Compiler(enum.Enum):
     PSYQ = "PSYQ"
     EGCS = "EGCS"
     MWCC = "MWCC"
+    EEGCC = "EEGCC"
 
     @staticmethod
     def fromStr(value: str) -> Compiler:

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -199,7 +199,7 @@ class GlobalConfigType:
 
     CUSTOM_SUFFIX: str = ""
 
-    COMPILER: Compiler = Compiler.IDO
+    COMPILER: Compiler = Compiler.GCC
 
     DETECT_REDUNDANT_FUNCTION_END: bool = False
     """Tries to detect redundant and unreferenced functions ends and merge them together.

--- a/spimdisasm/common/Relocation.py
+++ b/spimdisasm/common/Relocation.py
@@ -11,7 +11,6 @@ import enum
 from .ContextSymbols import ContextSymbol
 from .FileSectionType import FileSectionType
 from .GlobalConfig import GlobalConfig
-from .GlobalConfig import Compiler
 
 
 class RelocType(enum.Enum):
@@ -165,15 +164,7 @@ class RelocationInfo:
         if self.addend == 0:
             return name
 
-        # IDO always compiles assembly using modern GAS, for both whole files
-        # and splitted symbols. Using the workaround for addends outside the
-        # range of an s16 has different behavior in modern GAS.
-        if GlobalConfig.COMPILER == Compiler.IDO:
-            if self.addend < 0:
-                return f"{name} - 0x{-self.addend:X}"
-            return f"{name} + 0x{self.addend:X}"
-
-        if isSplittedSymbol:
+        if GlobalConfig.COMPILER.value.bigAddendWorkaroundForMigratedFunctions and isSplittedSymbol:
             if self.relocType == RelocType.MIPS_LO16:
                 if self.addend < -0x8000:
                     return f"{name} - (0x{-self.addend:X} & 0xFFFF)"

--- a/spimdisasm/common/__init__.py
+++ b/spimdisasm/common/__init__.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: © 2022-2024 Decompollaborate
 # SPDX-License-Identifier: MIT
 
-from . import Utils
+from . import Utils as Utils
 
 from .SortedDict import SortedDict as SortedDict
+from .CompilerConfig import CompilerProperties as CompilerProperties
+from .CompilerConfig import Compiler as Compiler
 from .GlobalConfig import GlobalConfig as GlobalConfig
 from .GlobalConfig import InputEndian as InputEndian
-from .GlobalConfig import Compiler as Compiler
 from .GlobalConfig import Abi as Abi
 from .GlobalConfig import ArchLevel as ArchLevel
 from .GlobalConfig import InputFileType as InputFileType

--- a/spimdisasm/mips/sections/MipsSectionRodata.py
+++ b/spimdisasm/mips/sections/MipsSectionRodata.py
@@ -135,8 +135,10 @@ class SectionRodata(SectionBase):
                         # doubles require a bit extra of alignment
                         if previousSymbolExtraPadding >= 2:
                             self.fileBoundaries.append(sym.inFileOffset)
-                    elif sym.isJumpTable() and common.GlobalConfig.COMPILER != common.Compiler.IDO:
-                        # non-IDO compilers emit a directive to align jumptables to 0x8 boundary
+                    elif sym.isJumpTable() and common.GlobalConfig.COMPILER.value.prevAlign_jumptable is not None and common.GlobalConfig.COMPILER.value.prevAlign_jumptable >= 3:
+                        if previousSymbolExtraPadding >= 2:
+                            self.fileBoundaries.append(sym.inFileOffset)
+                    elif sym.isString() and common.GlobalConfig.COMPILER.value.prevAlign_string is not None and common.GlobalConfig.COMPILER.value.prevAlign_string >= 3:
                         if previousSymbolExtraPadding >= 2:
                             self.fileBoundaries.append(sym.inFileOffset)
                     else:

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -517,37 +517,39 @@ class SymbolBase(common.ElementBase):
         "Returns how many extra word paddings this symbol has"
         return 0
 
-    def _getAlignDirectiveStr(self, shiftValue: int) -> str:
+    def _getAlignDirectiveStr(self, shiftValue: int, i: int) -> str:
         shiftedVal = 1 << shiftValue
 
         if self.parent is None:
             # Can't emit alignment directives if we don't have info about the parent
             return ""
 
-        subRam = self.vram - self.parent.vram
+        subRam = self.getVramOffset(i * 4) - self.parent.vram
         if subRam % shiftedVal != 0:
             # Alignment is relative to the file, not relative to the full binary
             return ""
 
         return f".align {shiftValue}{common.GlobalConfig.LINE_ENDS}"
 
-    def getPrevAlignDirective(self, i: int=0) -> str:
+    def getPrevAlignDirective(self, i: int) -> str:
         if self.isDouble(i):
             if common.GlobalConfig.COMPILER in {common.Compiler.SN64, common.Compiler.PSYQ}:
                 # This should be harmless in other compilers
                 # TODO: investigate if it is fine to use it unconditionally
-                return self._getAlignDirectiveStr(3)
+                return self._getAlignDirectiveStr(3, i)
         elif self.isJumpTable():
             if i == 0 and common.GlobalConfig.COMPILER not in {common.Compiler.IDO, common.Compiler.PSYQ}:
-                return self._getAlignDirectiveStr(3)
+                return self._getAlignDirectiveStr(3, i)
         elif self.isString() or self.isPascalString():
-            return self._getAlignDirectiveStr(2)
+            if common.GlobalConfig.COMPILER == common.Compiler.EEGCC:
+                return self._getAlignDirectiveStr(3, i)
+            return self._getAlignDirectiveStr(2, i)
 
         return ""
 
-    def getPostAlignDirective(self, i: int=0) -> str:
+    def getPostAlignDirective(self, i: int) -> str:
         if self.isString() or self.isPascalString():
-            return self._getAlignDirectiveStr(2)
+            return self._getAlignDirectiveStr(2, i)
 
         return ""
 

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -129,6 +129,9 @@ class SymbolBase(common.ElementBase):
             return f".size {symName}, . - {symName}{common.GlobalConfig.LINE_ENDS}"
         return ""
 
+    def isFunction(self) -> bool:
+        return False
+
     def isByte(self, index: int) -> bool:
         if self.isString() or self.isPascalString():
             return False
@@ -544,6 +547,9 @@ class SymbolBase(common.ElementBase):
             if common.GlobalConfig.COMPILER == common.Compiler.EEGCC:
                 return self._getAlignDirectiveStr(3, i)
             return self._getAlignDirectiveStr(2, i)
+        elif self.isFunction():
+            if common.GlobalConfig.COMPILER == common.Compiler.EEGCC:
+                return self._getAlignDirectiveStr(3, i)
 
         return ""
 

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -536,20 +536,22 @@ class SymbolBase(common.ElementBase):
 
     def getPrevAlignDirective(self, i: int) -> str:
         if self.isDouble(i):
-            if common.GlobalConfig.COMPILER in {common.Compiler.SN64, common.Compiler.PSYQ}:
-                # This should be harmless in other compilers
-                # TODO: investigate if it is fine to use it unconditionally
-                return self._getAlignDirectiveStr(3, i)
+            shiftValue = common.GlobalConfig.COMPILER.value.prevAlign_double
+            if shiftValue is not None:
+                return self._getAlignDirectiveStr(shiftValue, i)
         elif self.isJumpTable():
-            if i == 0 and common.GlobalConfig.COMPILER not in {common.Compiler.IDO, common.Compiler.PSYQ}:
-                return self._getAlignDirectiveStr(3, i)
+            if i == 0:
+                shiftValue = common.GlobalConfig.COMPILER.value.prevAlign_jumptable
+                if shiftValue is not None:
+                    return self._getAlignDirectiveStr(shiftValue, i)
         elif self.isString() or self.isPascalString():
-            if common.GlobalConfig.COMPILER == common.Compiler.EEGCC:
-                return self._getAlignDirectiveStr(3, i)
-            return self._getAlignDirectiveStr(2, i)
+            shiftValue = common.GlobalConfig.COMPILER.value.prevAlign_string
+            if shiftValue is not None:
+                return self._getAlignDirectiveStr(shiftValue, i)
         elif self.isFunction():
-            if common.GlobalConfig.COMPILER == common.Compiler.EEGCC:
-                return self._getAlignDirectiveStr(3, i)
+            shiftValue = common.GlobalConfig.COMPILER.value.prevAlign_function
+            if shiftValue is not None:
+                return self._getAlignDirectiveStr(shiftValue, i)
 
         return ""
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -36,6 +36,8 @@ class SymbolFunction(SymbolText):
     def sizew(self) -> int:
         return self.nInstr
 
+    def isFunction(self) -> bool:
+        return True
 
     def _lookAheadSymbolFinder(self, instr: rabbitizer.Instruction, prevInstr: rabbitizer.Instruction, instructionOffset: int, trackedRegistersOriginal: rabbitizer.RegistersTracker) -> None:
         if not prevInstr.isBranch() and not prevInstr.isUnconditionalBranch():
@@ -751,6 +753,7 @@ class SymbolFunction(SymbolText):
                 return self.disassembleAsData(useGlobalLabel=useGlobalLabel, isSplittedSymbol=isSplittedSymbol)
 
         output += self.contextSym.getReferenceeSymbols()
+        output += self.getPrevAlignDirective(0)
 
         if self.isLikelyHandwritten:
             if not self.isRsp:

--- a/spimdisasm/mips/symbols/MipsSymbolRodata.py
+++ b/spimdisasm/mips/symbols/MipsSymbolRodata.py
@@ -69,7 +69,7 @@ class SymbolRodata(SymbolBase):
             return True
 
         if self.isRdata():
-            if common.GlobalConfig.COMPILER not in {common.Compiler.SN64, common.Compiler.PSYQ}:
+            if not common.GlobalConfig.COMPILER.value.allowRdataMigration:
                 return False
 
         return True

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -199,7 +199,7 @@ class InstrAnalyzer:
                 # IDO does not pair multiples %hi to the same %lo
                 return self.symbolLoInstrOffset[lowerOffset]
 
-            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS, common.Compiler.MWCC, common.Compiler.EEGCC}:
+            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.KMC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS, common.Compiler.MWCC, common.Compiler.EEGCC}:
                 if luiOffset is None or hiValue is None:
                     return None
 

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -195,11 +195,11 @@ class InstrAnalyzer:
                         if hiValue != otherLuiInstr.getProcessedImmediate() << 16:
                             return None
 
-            if common.GlobalConfig.COMPILER == common.Compiler.IDO:
+            if not common.GlobalConfig.COMPILER.value.pairMultipleHiToSameLow:
                 # IDO does not pair multiples %hi to the same %lo
                 return self.symbolLoInstrOffset[lowerOffset]
 
-            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.KMC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS, common.Compiler.MWCC, common.Compiler.EEGCC}:
+            else:
                 if luiOffset is None or hiValue is None:
                     return None
 

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -199,7 +199,7 @@ class InstrAnalyzer:
                 # IDO does not pair multiples %hi to the same %lo
                 return self.symbolLoInstrOffset[lowerOffset]
 
-            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS, common.Compiler.MWCC}:
+            elif common.GlobalConfig.COMPILER in {common.Compiler.GCC, common.Compiler.SN64, common.Compiler.PSYQ, common.Compiler.EGCS, common.Compiler.MWCC, common.Compiler.EEGCC}:
                 if luiOffset is None or hiValue is None:
                     return None
 


### PR DESCRIPTION
## [1.24.0] - 2024-03-25

### Added

- Add `EEGCC` compiler option.
- Add `KMC` compiler option.

### Changed

- Emit `.align 3` directives for strings for `EEGCC` compiler.
- Emit `.align 3` directives for functions for `EEGCC` compiler.
- Refactor `Compiler` to make implementing per-compiler differences more easily.
