### PR TITLE
1.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.2] - 2024-03-26
+
 ### Added
 
 - `GlobalConfig.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION`.
@@ -1480,6 +1482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.24.2]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.1...1.24.2
 [1.24.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.0...1.24.1
 [1.24.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.1...1.24.0
 [1.23.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.0...1.23.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `GlobalConfig.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION`.
+  - Only emit symbol alignment directives if those are not larger than the
+    alignment of the disassembled section.
+
 ## [1.24.1] - 2024-03-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.24.1,<2.0.0
+spimdisasm>=1.24.2,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.24.2.dev0"
+version = "1.24.2"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.24.1"
+version = "1.24.2.dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 24, 2)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))# + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 24, 1)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__: tuple[int, int, int] = (1, 24, 2)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -164,6 +164,19 @@ class GlobalConfigType:
 
     COMPILER: Compiler = Compiler.IDO
 
+    SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION: bool = False
+    """If True then emitting an align directive affects the assembler so it
+    aligns the section to the biggest symbol alignment.
+
+    Some assemblers detect the biggest alignment of the symbols of the section
+    and apply said alignment to the section itself, while other assemblers
+    hardcode the section alignment even when there are symbols that have larger
+    alignment.
+
+    We need this information to determine if we can emit alignment directives
+    than would make the section to not be aligned in the final ROM.
+    """
+
     DETECT_REDUNDANT_FUNCTION_END: bool = False
     """Tries to detect redundant and unreferenced functions ends and merge them together.
     This option is ignored if the compiler is not set to IDO"""
@@ -333,6 +346,7 @@ A C string must start at a 0x4-aligned region, which is '\\0' terminated and pad
         backendConfig.add_argument("--custom-suffix", help="Set a custom suffix for automatically generated symbols")
 
         backendConfig.add_argument("--compiler", help=f"Enables some tweaks for the selected compiler. Defaults to {self.COMPILER.name}", choices=list(compilerOptions.keys()))
+        backendConfig.add_argument("--symbol-alignment-requires-aligned-section", help=f"Only emit symbol alignment directives if those are not larger than the alignment of the disassembled section. Defaults to {self.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION}", action=Utils.BooleanOptionalAction)
         backendConfig.add_argument("--detect-redundant-function-end", help=f"Tries to detect redundant and unreferenced function ends (jr $ra; nop), and merge it into the previous function. Currently it only is applied when the compiler is set to IDO. Defaults to {self.DETECT_REDUNDANT_FUNCTION_END}", action=Utils.BooleanOptionalAction)
 
         backendConfig.add_argument("--endian", help=f"Set the endianness of input files. Defaults to {self.ENDIAN.name.lower()}", choices=["big", "little", "middle"], default=self.ENDIAN.name.lower())
@@ -501,6 +515,9 @@ Defaults to {self.ASM_GLOBALIZE_TEXT_LABELS_REFERENCED_BY_NON_JUMPTABLE}""", act
 
         if args.compiler is not None:
             self.COMPILER = Compiler.fromStr(args.compiler)
+
+        if args.symbol_alignment_requires_aligned_section is not None:
+            self.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION = args.symbol_alignment_requires_aligned_section
 
         if args.detect_redundant_function_end is not None:
             self.DETECT_REDUNDANT_FUNCTION_END = args.detect_redundant_function_end

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -527,10 +527,19 @@ class SymbolBase(common.ElementBase):
             # Can't emit alignment directives if we don't have info about the parent
             return ""
 
-        subRam = self.getVramOffset(i * 4) - self.parent.vram
-        if subRam % shiftedVal != 0:
-            # Alignment is relative to the file, not relative to the full binary
-            return ""
+        if common.GlobalConfig.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION:
+            if self.parent.vram % shiftedVal != 0:
+                # Can't emit alignment directives if the parent file isn't properly aligned
+                return ""
+
+            if self.getVramOffset(i * 4) % shiftedVal != 0:
+                # If the symbol itself isn't already aligned to the desired alignment then the directive would break matching
+                return ""
+        else:
+            subRam = self.getVramOffset(i * 4) - self.parent.vram
+            if subRam % shiftedVal != 0:
+                # Alignment is relative to the file, not relative to the full binary
+                return ""
 
         return f".align {shiftValue}{common.GlobalConfig.LINE_ENDS}"
 


### PR DESCRIPTION
## [1.24.2] - 2024-03-26

### Added

- `GlobalConfig.SYMBOL_ALIGNMENT_REQUIRES_ALIGNED_SECTION`.
  - Only emit symbol alignment directives if those are not larger than the
    alignment of the disassembled section.
