### PR TITLE
1.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New behavior do follows branches during look ahead analysis, improving
     symbol pairing but making a bit slower the time needed for the overall
     analysis.
+- rabbitizer 1.9.4 or above is required.
+  - Should fix some issues under Windows.
 
 ## [1.24.2] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.3] - 2024-04-24
+
+### Changed
+
+- Instruction analysis now follow all branches during look ahead analysis.
+  - Look ahead analysis consists on taking branches and trying to follow the
+    control flow without interrumping the main function analysis.
+  - Old behavior trigered the look ahead analysis on a branch, but if a second
+    branch was found during the look ahead analysis then it was ignored and not
+    taken. This lead to some pointers not being properly paired if the codegen
+    emitted the `%hi` and `%lo` separated by too many branches.
+  - New behavior do follows branches during look ahead analysis, improving
+    symbol pairing but making a bit slower the time needed for the overall
+    analysis.
+
 ## [1.24.2] - 2024-03-26
 
 ### Added
@@ -1482,6 +1497,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.24.3]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.2...1.24.3
 [1.24.2]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.1...1.24.2
 [1.24.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.0...1.24.1
 [1.24.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.23.1...1.24.0

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.24.2,<2.0.0
+spimdisasm>=1.24.3,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.24.3.dev0"
+version = "1.24.3"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.24.2"
+version = "1.24.3.dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.7.0,<2.0.0
+rabbitizer>=1.9.4,<2.0.0

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 24, 2)
-__version__ = ".".join(map(str, __version_info__))# + ".dev0"
+__version_info__: tuple[int, int, int] = (1, 24, 3)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 24, 3)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))# + ".dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -70,6 +70,14 @@ class SymbolFunction(SymbolText):
 
             self._lookAheadSymbolFinder(targetInstr, prevTargetInstr, branch, regsTracker)
 
+            if prevTargetInstr.isUnconditionalBranch():
+                # Since we took the branch on the previous _lookAheadSymbolFinder
+                # call then we don't have anything else to process here.
+                return
+            if prevTargetInstr.isJump() and not prevTargetInstr.doesLink():
+                # Technically this is another form of unconditional branching.
+                return
+
             self.instrAnalyzer.processPrevFuncCall(regsTracker, targetInstr, prevTargetInstr)
             branch += 4
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -46,7 +46,6 @@ class SymbolFunction(SymbolText):
         currentVram = self.getVramOffset(instructionOffset)
 
         prevInstrOffset = instructionOffset - 4
-        prevVram = self.getVramOffset(prevInstrOffset)
         branchOffset = prevInstr.getBranchOffsetGeneric()
         branch = prevInstrOffset + branchOffset
 
@@ -69,10 +68,7 @@ class SymbolFunction(SymbolText):
 
             self.instrAnalyzer.processInstr(regsTracker, targetInstr, branch, self.getVramOffset(branch), prevTargetInstr)
 
-            if prevTargetInstr.isUnconditionalBranch():
-                return
-            if prevTargetInstr.isJump() and not prevTargetInstr.doesLink():
-                return
+            self._lookAheadSymbolFinder(targetInstr, prevTargetInstr, branch, regsTracker)
 
             self.instrAnalyzer.processPrevFuncCall(regsTracker, targetInstr, prevTargetInstr)
             branch += 4


### PR DESCRIPTION
## [1.24.3] - 2024-04-24

### Changed

- Instruction analysis now follow all branches during look ahead analysis.
  - Look ahead analysis consists on taking branches and trying to follow the
    control flow without interrumping the main function analysis.
  - Old behavior trigered the look ahead analysis on a branch, but if a second
    branch was found during the look ahead analysis then it was ignored and not
    taken. This lead to some pointers not being properly paired if the codegen
    emitted the `%hi` and `%lo` separated by too many branches.
  - New behavior do follows branches during look ahead analysis, improving
    symbol pairing but making a bit slower the time needed for the overall
    analysis.
- rabbitizer 1.9.4 or above is required.
  - Should fix some issues under Windows.
