### PR TITLE
1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.24.3] - 2024-04-24
+## [1.25.0] - 2024-04-22
+
+### Added
+
+- R4000 ALLEGREX instruction set compatibility
+  - Used by the PlayStation Portable (PSP) CPU.
+- `rabbitizer` 1.10.0 or above is required.
+
+## [1.24.3] - 2024-04-04
 
 ### Changed
 
@@ -1499,6 +1507,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.25.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.3...1.25.0
 [1.24.3]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.2...1.24.3
 [1.24.2]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.1...1.24.2
 [1.24.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.24.0...1.24.1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ MIPS platforms too.
     - RSP decoding has been tested to build back to matching assemblies with
       [armips](https://github.com/Kingcom/armips/).
   - PS1's R3000 GTE instruction set support.
+  - PSP's R4000 ALLEGREX instruction set support.
   - PS2's R5900 EE instruction set support.
 - (Experimental) Same VRAM overlay support.
   - Overlays which are able to reference symbols from other overlays in other
@@ -68,7 +69,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.24.3,<2.0.0
+spimdisasm>=1.25.0,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.24.3"
+version = "1.25.0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.9.4,<2.0.0
+rabbitizer>=1.10.0,<2.0.0

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 24, 3)
+__version_info__: tuple[int, int, int] = (1, 25, 0)
 __version__ = ".".join(map(str, __version_info__))# + ".dev0"
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/disasmdis/DisasmdisInternals.py
+++ b/spimdisasm/disasmdis/DisasmdisInternals.py
@@ -27,7 +27,7 @@ def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     parser.add_argument("input", help="Hex words to be disassembled. Leading '0x' must be omitted", nargs='+')
 
     parser.add_argument("--endian", help="Set the endianness of input files. Defaults to 'big'", choices=["big", "little", "middle"], default="big")
-    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r5900"])
+    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r4000allegrex", "r5900"])
     parser.add_argument("--pseudos", help="Enables all pseudo-instructions supported by rabbitizer", action="store_true")
 
     return parser

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -34,7 +34,7 @@ def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     parser.add_argument("--split-functions", help="Enables the function and rodata splitter. Expects a path to place the splited functions", metavar="PATH")
 
-    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r5900"])
+    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r4000allegrex", "r5900"])
 
     parser.add_argument("--function-info", help="Specifies a path where to output a csvs sumary file of every analyzed function", metavar="PATH")
 

--- a/spimdisasm/frontendCommon/FrontendUtilities.py
+++ b/spimdisasm/frontendCommon/FrontendUtilities.py
@@ -72,6 +72,7 @@ gInstrCategoriesNameMap = {
     "cpu": rabbitizer.InstrCategory.CPU,
     "rsp": rabbitizer.InstrCategory.RSP,
     "r3000gte": rabbitizer.InstrCategory.R3000GTE,
+    "r4000allegrex": rabbitizer.InstrCategory.R4000ALLEGREX,
     "r5900": rabbitizer.InstrCategory.R5900,
 }
 

--- a/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
+++ b/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
@@ -42,7 +42,7 @@ def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     parser.add_argument("--split-functions", help="Enables the function and rodata splitter. Expects a path to place the splited functions", metavar="PATH")
 
-    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r5900"])
+    parser.add_argument("--instr-category", help="The instruction category to use when disassembling every passed instruction. Defaults to 'cpu'", choices=["cpu", "rsp", "r3000gte", "r4000allegrex", "r5900"])
 
     parser.add_argument("--nuke-pointers", help="Use every technique available to remove pointers", action=common.Utils.BooleanOptionalAction)
     parser.add_argument("--ignore-words", help="A space separated list of hex numbers. Any word differences which starts in any of the provided arguments will be ignored. Max value: FF. Only works when --nuke-pointers is passed", action="extend", nargs="+")


### PR DESCRIPTION
## [1.25.0] - 2024-04-22

### Added

- R4000 ALLEGREX instruction set compatibility
  - Used by the PlayStation Portable (PSP) CPU.
- `rabbitizer` 1.10.0 or above is required.

