### PR TITLE
1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `MIPS_SCOMMON` and `MIPS_SUNDEFINED` to elfObjDisasm's readelf
-  reimplementation.
+- elfObjDisasm's readelf:
+  - Add `MIPS_SCOMMON` and `MIPS_SUNDEFINED` support in symtab.
+  - Use the section name in the ndx column instead of a plain number for
+    `OBJECT`s and `FUNC`s.
+
+### Fixed
+
+- elfObjDisasm's readelf:
+  - Fix name column not displaying the section's name.
 
 ## [1.27.0] - 2024-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use the section name in the ndx column instead of a plain number for
     `OBJECT`s and `FUNC`s.
 
+### Changed
+
+- Try to detect function pointers used on tail call optimizations and try to not
+  confuse them with detected jumptables.
+- rabbitizer 1.12.0 or above is required.
+
 ### Fixed
 
 - Fix rodata addresses referenced _only_ by other rodata symbols on the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - elfObjDisasm's readelf:
   - Fix name column not displaying the section's name.
+  - Fix relocation sections not displaying anything on the name columns for
+    relocations relative to a section instead of a symbol.
 
 ## [1.27.0] - 2024-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MIPS_SCOMMON` and `MIPS_SUNDEFINED` to elfObjDisasm's readelf
+  reimplementation.
+
 ## [1.27.0] - 2024-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.0] - 2024-08-09
+
 ### Added
 
 - New `SectionText.gpRelHack` setting.
@@ -1591,7 +1593,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
-[1.27.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.27.0...1.27.0
+[1.28.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.27.0...1.28.0
+[1.27.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.26.1...1.27.0
 [1.26.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.26.0...1.26.1
 [1.26.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.25.1...1.26.0
 [1.25.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.25.0...1.25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix rodata addresses referenced _only_ by other rodata symbols on the same
+  file not being properly symbolized.
 - elfObjDisasm's readelf:
   - Fix name column not displaying the section's name.
   - Fix relocation sections not displaying anything on the name columns for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `SectionText.gpRelHack` setting.
+  - Turning it on changes all instructions that use a `%gp_rel` reloc into macro
+    instructions that do not specify the relocation explicitly nor reference the
+    `$gp` register.
+  - This may even change some instruction mnemonics, like replacing `addiu` into
+    `la`.
+  - This is required by old assemblers that do not support explicit `%gp_rel`
+    relocations, but instead they infer the relocation to be used by checking
+    if the symbol was defined in the assembly file and its size fits on the
+    passed `-G` parameter.
+  - WARNING: It is the user's responsability to provide those symbol definitions
+    to the assembler, otherwise those instructions will be expanded into
+    multiple instructions and produce a shifted build.
 - elfObjDisasm's readelf:
   - Add `MIPS_SCOMMON` and `MIPS_SUNDEFINED` support in symtab.
   - Use the section name in the ndx column instead of a plain number for

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.27.0,<2.0.0
+spimdisasm>=1.28.0,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.27.1-dev0"
+version = "1.28.0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.27.0"
+version = "1.27.1-dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.10.0,<2.0.0
+rabbitizer>=1.12.0,<2.0.0

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 27, 0)
-__version__ = ".".join(map(str, __version_info__))# + ".dev0"
+__version_info__: tuple[int, int, int] = (1, 27, 1)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 27, 1)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version_info__: tuple[int, int, int] = (1, 28, 0)
+__version__ = ".".join(map(str, __version_info__))# + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -426,6 +426,23 @@ class ContextSymbol:
         # if self.referenceCounter > 1: return False # ?
         return self.isJumpTable() or self.isFloat() or self.isDouble()
 
+
+    def notPointerByType(self) -> bool:
+        if self.isByte():
+            return True
+        if self.isShort():
+            return True
+        if self.isFloat():
+            return True
+        if self.isDouble():
+            return True
+        if self.isString():
+            return True
+        if self.isPascalString():
+            return True
+        return False
+
+
     def hasUserDeclaredSize(self) -> bool:
         return self.userDeclaredSize is not None
 

--- a/spimdisasm/common/Relocation.py
+++ b/spimdisasm/common/Relocation.py
@@ -175,11 +175,13 @@ class RelocationInfo:
             return f"{name} - 0x{-self.addend:X}"
         return f"{name} + 0x{self.addend:X}"
 
-    def getNameWithReloc(self, isSplittedSymbol: bool=False) -> str:
+    def getNameWithReloc(self, *, isSplittedSymbol: bool=False, ignoredRelocs: set[RelocType]=set()) -> str:
         name = self.getName(isSplittedSymbol=isSplittedSymbol)
 
         percentRel = self.relocType.getPercentRel()
         if percentRel is not None:
+            if self.relocType in ignoredRelocs:
+                return f"({name})"
             return f"{percentRel}({name})"
 
         wordRel = self.relocType.getWordRel()

--- a/spimdisasm/elf32/Elf32Constants.py
+++ b/spimdisasm/elf32/Elf32Constants.py
@@ -346,9 +346,11 @@ class Elf32SectionHeaderNumber(enum.Enum):
     UNDEF           = 0
     ABS             = 0xFFF1
     COMMON          = 0xFFF2
-    MIPS_ACOMMON    = 0xFF00
-    MIPS_TEXT       = 0xFF01
-    MIPS_DATA       = 0xFF02
+    MIPS_ACOMMON    = 0xFF00 # Allocated common symbols.
+    MIPS_TEXT       = 0xFF01 # Allocated test symbols.
+    MIPS_DATA       = 0xFF02 # Allocated data symbols.
+    MIPS_SCOMMON    = 0xFF03 # Small common symbols.
+    MIPS_SUNDEFINED = 0xFF04 # Small undefined symbols.
 
     @staticmethod
     def fromValue(value: int) -> Elf32SectionHeaderNumber|None:

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -543,7 +543,7 @@ class Elf32File:
 
         print(f"Symbol table '{symbolTableName}' contains {len(symbolTable.symbols)} entries:")
 
-        print(f" {'Num':>5}: {'Value':>8} {'Size':>5} {'Type':7} {'Bind':6} {'Vis':9} {'Ndx':>12} {'Name'}")
+        print(f" {'Num':>5}: {'Value':>8} {'Size':>5} {'Type':7} {'Bind':6} {'Vis':9} {'Ndx':>15} {'Name'}")
 
         for i, sym in enumerate(symbolTable.symbols):
             entryType = Elf32SymbolTableType(sym.stType)
@@ -566,7 +566,7 @@ class Elf32File:
             symName = ""
             if stringTable is not None:
                 symName = stringTable[sym.name]
-            print(f" {i:>5}: {sym.value:08X} {sym.size:>5X} {entryType.name:7} {bind:6} {visibility:9} {ndx:>12} {symName}")
+            print(f" {i:>5}: {sym.value:08X} {sym.size:>5X} {entryType.name:7} {bind:6} {visibility:9} {ndx:>15} {symName}")
 
         print()
 

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -613,6 +613,13 @@ class Elf32File:
                     symValue = f"{sym.value:08X}"
                     if self.strtab is not None:
                         symName = self.strtab[sym.name]
+                if symName == "":
+                    # Some relocations are an offset to a section on the current object instead of to a symtab symbol.
+                    # TODO: what is the proper way to check this?
+                    section = self.sectionHeaders[sym.shndx]
+                    if section is not None:
+                        symName = self.shstrtab[section.name]
+
                 print(f" {rel.offset:08X} {rel.info:08X} {relType:<12} {symValue:>9} {symName}")
 
             print()

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -562,10 +562,22 @@ class Elf32File:
             shndx = Elf32SectionHeaderNumber.fromValue(sym.shndx)
             if shndx is not None:
                 ndx = shndx.name
+            elif entryType in { Elf32SymbolTableType.OBJECT, Elf32SymbolTableType.FUNC }:
+                # spimdisasm-extension: instead of a number we use the section name if available
+                section = self.sectionHeaders[sym.shndx]
+                if section is not None:
+                    ndx = self.shstrtab[section.name]
 
             symName = ""
             if stringTable is not None:
                 symName = stringTable[sym.name]
+            if symName == "":
+                # GNU readelf uses the section's name as the name column for sections instead of the symbol's name.
+                if entryType == Elf32SymbolTableType.SECTION:
+                    section = self.sectionHeaders[sym.shndx]
+                    if section is not None:
+                        symName = self.shstrtab[section.name]
+
             print(f" {i:>5}: {sym.value:08X} {sym.size:>5X} {entryType.name:7} {bind:6} {visibility:9} {ndx:>15} {symName}")
 
         print()

--- a/spimdisasm/elf32/Elf32SectionHeaders.py
+++ b/spimdisasm/elf32/Elf32SectionHeaders.py
@@ -64,6 +64,12 @@ class Elf32SectionHeaders:
             return self.mipsText
         if key == Elf32SectionHeaderNumber.MIPS_DATA.value:
             return self.mipsData
+        if key == Elf32SectionHeaderNumber.MIPS_SCOMMON.value:
+            common.Utils.eprint("Warning: Elf32SectionHeaderNumber.MIPS_SCOMMON not implemented\n")
+            return None
+        if key == Elf32SectionHeaderNumber.MIPS_SUNDEFINED.value:
+            common.Utils.eprint("Warning: Elf32SectionHeaderNumber.MIPS_SUNDEFINED not implemented\n")
+            return None
         if key > len(self.sections):
             return None
         return self.sections[key]

--- a/spimdisasm/mips/sections/MipsSectionData.py
+++ b/spimdisasm/mips/sections/MipsSectionData.py
@@ -54,7 +54,6 @@ class SectionData(SectionBase):
             localOffset = 0
             for w in self.words:
                 currentVram = self.getVramOffset(localOffset)
-                currentVrom = self.getVromOffset(localOffset)
 
                 if self.popPointerInDataReference(currentVram) is not None and localOffset not in localOffsetsWithSymbols:
                     contextSym = self._addOwnedSymbol(localOffset)

--- a/spimdisasm/mips/sections/MipsSectionText.py
+++ b/spimdisasm/mips/sections/MipsSectionText.py
@@ -21,6 +21,8 @@ class SectionText(SectionBase):
 
         self.instrCat: rabbitizer.Enum = rabbitizer.InstrCategory.CPU
         self.detectRedundantFunctionEnd: bool|None = None
+        self.gpRelHack: bool = False
+        """Get rid of `%gp_rel` and `$gp` since old assemblers don't support `%gp_rel`."""
 
         self.enableStringGuessing = False
 
@@ -319,6 +321,7 @@ class SectionText(SectionBase):
             func.hasUnimplementedIntrs = hasUnimplementedIntrs
             func.parent = self
             func.isRsp = self.instrCat == rabbitizer.InstrCategory.RSP
+            func.gpRelHack = self.gpRelHack
             func.analyze()
             self.symbolList.append(func)
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -27,6 +27,7 @@ class SymbolFunction(SymbolText):
         self.hasUnimplementedIntrs: bool = False
         self.isRsp: bool = False
         self.isLikelyHandwritten: bool = False
+        self.gpRelHack: bool = False
 
     @property
     def nInstr(self) -> int:
@@ -645,38 +646,41 @@ class SymbolFunction(SymbolText):
         return None
 
 
-    def getImmOverrideForInstruction(self, instr: rabbitizer.Instruction, instrOffset: int, isSplittedSymbol: bool=False) -> str|None:
+    def _getImmOverrideForInstruction(self, instr: rabbitizer.Instruction, instrOffset: int, isSplittedSymbol: bool=False) -> tuple[str|None, common.RelocationInfo|None]:
         if self.pointersRemoved:
-            return None
+            return None, None
 
         relocInfo = self.getReloc(instrOffset, instr)
         if relocInfo is not None and not relocInfo.isRelocNone():
-            return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
+            ignoredRelocs = set()
+            if self.gpRelHack:
+                ignoredRelocs.add(common.RelocType.MIPS_GPREL16)
+            return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol, ignoredRelocs=ignoredRelocs), relocInfo
 
         if instr.isBranch() or instr.isUnconditionalBranch():
             if common.GlobalConfig.IGNORE_BRANCHES:
-                return None
+                return None, None
             branchOffset = instr.getBranchOffsetGeneric()
             targetBranchVram = self.getVramOffset(instrOffset + branchOffset)
             labelSymbol = self.getSymbol(targetBranchVram, tryPlusOffset=False)
             if labelSymbol is not None:
-                return labelSymbol.getName()
-            return None
+                return labelSymbol.getName(), None
+            return None, None
 
         if instr.hasOperandAlias(rabbitizer.OperandType.cpu_immediate):
             if instrOffset in self.instrAnalyzer.symbolInstrOffset:
                 address = self.instrAnalyzer.symbolInstrOffset[instrOffset]
                 relocInfo = self._generateHiLoConstantReloc(address, instr, instr)
                 if relocInfo is not None:
-                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
+                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol), relocInfo
 
             elif instr.canBeHi():
                 # Unpaired LUI
                 relocInfo = self._generateHiLoConstantReloc(instr.getProcessedImmediate()<<16, instr, None)
                 if relocInfo is not None:
-                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol)
+                    return relocInfo.getNameWithReloc(isSplittedSymbol=isSplittedSymbol), relocInfo
 
-        return None
+        return None, None
 
     def getLabelForOffset(self, instructionOffset: int, migrate: bool=False) -> str:
         if common.GlobalConfig.IGNORE_BRANCHES or instructionOffset == 0:
@@ -714,7 +718,7 @@ class SymbolFunction(SymbolText):
         return labelSym.getName() + ":" + common.GlobalConfig.LINE_ENDS
 
     def _emitInstruction(self, instr: rabbitizer.Instruction, instructionOffset: int, wasLastInstABranch: bool, isSplittedSymbol: bool=False) -> str:
-        immOverride = self.getImmOverrideForInstruction(instr, instructionOffset, isSplittedSymbol=isSplittedSymbol)
+        immOverride, relocInfo = self._getImmOverrideForInstruction(instr, instructionOffset, isSplittedSymbol=isSplittedSymbol)
         comment = self.generateAsmLineComment(instructionOffset, instr.getRaw())
         extraLJust = 0
 
@@ -723,6 +727,31 @@ class SymbolFunction(SymbolText):
             comment += " "
 
         line = instr.disassemble(immOverride, extraLJust=extraLJust)
+
+        if self.gpRelHack:
+            # Get rid of `%gp_rel` and `$gp` since old assemblers don't support `%gp_rel`.
+            #
+            # We convert the explicit instructions with relocations into macro/pseudo
+            # instructions and hope for the assembler to do the right thing.
+            #
+            # A few examples for the conversions (right being the macro instructions):
+            # `lw     $v0, %gp_rel(example_var)($gp)` -> `lw     $v0, (example_var)`
+            # `addiu  $v0, $gp, %gp_rel(example_var)` -> `la     $v0, (example_var)`
+            #
+            # Those assemblers will actually assemble those macro instructions into the
+            # proper ones with gp_rel relocations only if they can also see the symbol
+            # defined on the same assembly file and its size fits within the passed `-G`
+            # parameter. It is the user's responsability to provide those definitions to
+            # the assembler.
+            if relocInfo is not None and relocInfo.relocType == common.RelocType.MIPS_GPREL16:
+                if instr.canBeLo() and instr.doesDereference():
+                    line = line.replace("($gp)", "").replace("($28)", "")
+                elif instr.uniqueId == rabbitizer.InstrId.cpu_addiu:
+                    line = line.replace("addiu ", "la    ").replace(", $gp, ", ", ").replace(", $28, ", ", ")
+
+                endComment = self.endOfLineComment.get(instructionOffset//4, "")
+                endComment += f" /* gp_rel: {immOverride} */"
+                self.endOfLineComment[instructionOffset//4] = endComment
 
         return f"{comment}  {line}"
 

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -509,6 +509,10 @@ class SymbolFunction(SymbolText):
             jumpTable.parentFunction = self.contextSym
             self.contextSym.jumpTables.add(jumpTable.vram, jumpTable)
 
+        # To debug jumptable rejection change this check to `True`
+        if False:
+            for jrInstrOffset, (referenceOffset, jtblAddress, branchOffset) in self.instrAnalyzer.rejectedjumpRegisterIntrOffset.items():
+                self.endOfLineComment[jrInstrOffset//4] = f" /* Jumping to something at address 0x{jtblAddress:08X} (inferred from 0x{self.getVromOffset(referenceOffset):X}). Jumptable rejected by instruction at vrom 0x{self.getVromOffset(branchOffset):X} */"
 
         if self.isLikelyHandwritten:
             for instr in self.instructions:


### PR DESCRIPTION
## [1.28.0] - 2024-08-09

### Added

- New `SectionText.gpRelHack` setting.
  - Turning it on changes all instructions that use a `%gp_rel` reloc into macro
    instructions that do not specify the relocation explicitly nor reference the
    `$gp` register.
  - This may even change some instruction mnemonics, like replacing `addiu` into
    `la`.
  - This is required by old assemblers that do not support explicit `%gp_rel`
    relocations, but instead they infer the relocation to be used by checking
    if the symbol was defined in the assembly file and its size fits on the
    passed `-G` parameter.
  - WARNING: It is the user's responsability to provide those symbol definitions
    to the assembler, otherwise those instructions will be expanded into
    multiple instructions and produce a shifted build.
- elfObjDisasm's readelf:
  - Add `MIPS_SCOMMON` and `MIPS_SUNDEFINED` support in symtab.
  - Use the section name in the ndx column instead of a plain number for
    `OBJECT`s and `FUNC`s.

### Changed

- Try to detect function pointers used on tail call optimizations and try to not
  confuse them with detected jumptables.
- rabbitizer 1.12.0 or above is required.

### Fixed

- Fix rodata addresses referenced _only_ by other rodata symbols on the same
  file not being properly symbolized.
- elfObjDisasm's readelf:
  - Fix name column not displaying the section's name.
  - Fix relocation sections not displaying anything on the name columns for
    relocations relative to a section instead of a symbol.
