### PR TITLE
1.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a crash produced by not handling new `AccessType`s introduced by `rabbitizer`.
+- `rabbitizer` 1.12.5 or above is required.
+
 ## [1.31.2] - 2024-12-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.3] - 2024-12-21
+
 ### Fixed
 
 - Fix a crash produced by not handling new `AccessType`s introduced by `rabbitizer`.
@@ -1718,6 +1720,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.31.3]: https://github.com/Decompollaborate/spimdisasm/compare/1.31.2...1.31.3
 [1.31.2]: https://github.com/Decompollaborate/spimdisasm/compare/1.31.1...1.31.2
 [1.31.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.31.0...1.31.1
 [1.31.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.30.2...1.31.0

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.31.2,<2.0.0
+spimdisasm>=1.31.3,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.31.2"
+version = "1.31.3-dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.31.3-dev0"
+version = "1.31.3"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.12.0,<2.0.0
+rabbitizer>=1.12.5,<2.0.0

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 31, 3)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version__ = ".".join(map(str, __version_info__))# + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 31, 2)
-__version__ = ".".join(map(str, __version_info__))# + "-dev0"
+__version_info__: tuple[int, int, int] = (1, 31, 3)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common


### PR DESCRIPTION
## [1.31.3] - 2024-12-21

### Fixed

- Fix a crash produced by not handling new `AccessType`s introduced by `rabbitizer`.
- `rabbitizer` 1.12.5 or above is required.
