### PR TITLE
1.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.2] - 2025-02-12
+
 ### Fixed
 
 - Fix to avoid incorrectly inferring the symbol's type if the given symbol is
@@ -1749,6 +1751,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.32.2]: https://github.com/Decompollaborate/spimdisasm/compare/1.32.1...1.32.2
 [1.32.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.32.0...1.32.1
 [1.32.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.31.3...1.32.0
 [1.31.3]: https://github.com/Decompollaborate/spimdisasm/compare/1.31.2...1.31.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix to avoid incorrectly inferring the symbol's type if the given symbol is
   referenced on complex control flows.
+- Avoid symbolizing $gp accesses if the current function set that register to a
+  different value.
 
 ## [1.32.1] - 2025-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix to avoid incorrectly inferring the symbol's type if the given symbol is
+  referenced on complex control flows.
+
 ## [1.32.1] - 2025-02-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.32.1,<2.0.0
+spimdisasm>=1.32.2,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.32.1"
+version = "1.32.2"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 32, 2)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version__ = ".".join(map(str, __version_info__))# + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 32, 1)
-__version__ = ".".join(map(str, __version_info__))# + "-dev0"
+__version_info__: tuple[int, int, int] = (1, 32, 2)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -380,6 +380,8 @@ class SymbolFunction(SymbolText):
             self.relocs[instrOffset] = common.RelocationInfo(relocType, "_gp_disp")
 
         for instrOffset, gpInfo in self.instrAnalyzer.gpSets.items():
+            if gpInfo is None:
+                continue
             hiInstrOffset = gpInfo.hiOffset
             hiInstr = self.instructions[hiInstrOffset//4]
             instr = self.instructions[instrOffset//4]

--- a/spimdisasm/mips/symbols/MipsSymbolFunction.py
+++ b/spimdisasm/mips/symbols/MipsSymbolFunction.py
@@ -19,7 +19,7 @@ class SymbolFunction(SymbolText):
 
         self.instrAnalyzer = analysis.InstrAnalyzer(self.vram, context)
 
-        self.branchesTaken: set[int] = set()
+        self.branchesTaken: set[tuple[int, bool]] = set()
 
         self.pointersOffsets: set[int] = set()
         self.pointersRemoved: bool = False
@@ -40,7 +40,7 @@ class SymbolFunction(SymbolText):
     def isFunction(self) -> bool:
         return True
 
-    def _lookAheadSymbolFinder(self, instr: rabbitizer.Instruction, prevInstr: rabbitizer.Instruction, instructionOffset: int, trackedRegistersOriginal: rabbitizer.RegistersTracker) -> None:
+    def _lookAheadSymbolFinder(self, instr: rabbitizer.Instruction, prevInstr: rabbitizer.Instruction, instructionOffset: int, trackedRegistersOriginal: rabbitizer.RegistersTracker, prev_is_likely: bool) -> None:
         if not prevInstr.isBranch() and not prevInstr.isUnconditionalBranch():
             return
 
@@ -58,9 +58,9 @@ class SymbolFunction(SymbolText):
 
         self.instrAnalyzer.processInstr(regsTracker, instr, instructionOffset, currentVram, None)
 
-        if instructionOffset in self.branchesTaken:
+        if (instructionOffset, prev_is_likely) in self.branchesTaken:
             return
-        self.branchesTaken.add(instructionOffset)
+        self.branchesTaken.add((instructionOffset, prev_is_likely))
 
         sizew = len(self.instructions)*4
         while branch < sizew:
@@ -69,7 +69,7 @@ class SymbolFunction(SymbolText):
 
             self.instrAnalyzer.processInstr(regsTracker, targetInstr, branch, self.getVramOffset(branch), prevTargetInstr)
 
-            self._lookAheadSymbolFinder(targetInstr, prevTargetInstr, branch, regsTracker)
+            self._lookAheadSymbolFinder(targetInstr, prevTargetInstr, branch, regsTracker, prev_is_likely or prevTargetInstr.isBranchLikely())
 
             if prevTargetInstr.isUnconditionalBranch():
                 # Since we took the branch on the previous _lookAheadSymbolFinder
@@ -129,7 +129,7 @@ class SymbolFunction(SymbolText):
                 self.instrAnalyzer.processInstr(regsTracker, instr, instructionOffset, currentVram, prevInstr)
 
             # look-ahead symbol finder
-            self._lookAheadSymbolFinder(instr, prevInstr, instructionOffset, regsTracker)
+            self._lookAheadSymbolFinder(instr, prevInstr, instructionOffset, regsTracker, prevInstr.isBranchLikely())
 
             if prevInstr.isJumpWithAddress() and not prevInstr.doesLink():
                 targetVram = prevInstr.getBranchVramGeneric()


### PR DESCRIPTION
## [1.32.2] - 2025-02-12

### Fixed

- Fix to avoid incorrectly inferring the symbol's type if the given symbol is
  referenced on complex control flows.
- Avoid symbolizing $gp accesses if the current function set that register to a
  different value.
