### PR TITLE
Fix some bugs when using .dummy in a csv config file

### DIFF
--- a/spimdisasm/common/FileSplitFormat.py
+++ b/spimdisasm/common/FileSplitFormat.py
@@ -53,6 +53,9 @@ class FileSplitFormat:
             if possibleSection != FileSectionType.Invalid:
                 if possibleSection == FileSectionType.End:
                     break
+                elif possibleSection == FileSectionType.Dummy:
+                    # ignore dummy sections
+                    continue
                 else:
                     section = possibleSection
                     continue

--- a/spimdisasm/common/FileSplitFormat.py
+++ b/spimdisasm/common/FileSplitFormat.py
@@ -61,7 +61,7 @@ class FileSplitFormat:
             offset = int(offsetStr, 16)
             nextOffset = 0xFFFFFF
             if i + 1 < len(self.splits):
-                if self.splits[i+1][2] == ".end":
+                if self.splits[i+1][2] in (".end", ".dummy"):
                     nextOffsetStr = self.splits[i+1][0]
                 elif self.splits[i+1][2].startswith("."):
                     nextOffsetStr = self.splits[i+2][0]


### PR DESCRIPTION
In particular:
1. When creating a section, use the dummy's offset for the previous splits nextOffset
2. Ignore dummy sections when iterating through file splits