### PR TITLE
Strip after splitting off csv comments

### DIFF
--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -165,7 +165,7 @@ def readCsv(filepath: Path) -> list[list[str]]:
 
     with filepath.open() as f:
         lines = f.readlines()
-        processedLines = [x.strip().split("#")[0] for x in lines]
+        processedLines = [x.split("#")[0].strip() for x in lines]
         csvReader = csv.reader(processedLines)
         for row in csvReader:
             data.append(list(row))


### PR DESCRIPTION
Otherwise we keep any spaces between the line and the comment.

`16960,800969C0,.dummy # src/boot/rspboot`
gets parsed as
Before:
`16960,800969C0,.dummy `
(note the trailing space after dummy)
After:
`16960,800969C0,.dummy`

As is currently, the proper way to have a comment is to have the `#` immediately after the valid line with no space
e.g `16960,800969C0,.dummy# src/boot/rspboot`
which is just awkward.