### PR TITLE
Skip creating sections for dummy segments in FileSplits

### DIFF
--- a/spimdisasm/mips/MipsFileSplits.py
+++ b/spimdisasm/mips/MipsFileSplits.py
@@ -74,6 +74,10 @@ class FileSplits(FileBase):
             # if self.vram is None:
             #     self.vram = splitEntry.vram
 
+            if splitEntry.section == common.FileSectionType.Dummy:
+                # Ignore dummy sections
+                continue
+
             f = FilesHandlers.createSectionFromSplitEntry(splitEntry, array_of_bytes, context, vromStart)
             f.parent = self
             f.setCommentOffset(splitEntry.offset)


### PR DESCRIPTION
Similar to `getSplittedSections` in `FrontendUtilities.py` skip processing of dummy segments when creating sections.